### PR TITLE
forced removal/addition of sources based on what's submitted via Services UI.

### DIFF
--- a/assemblyline_ui/api/base.py
+++ b/assemblyline_ui/api/base.py
@@ -94,7 +94,8 @@ class api_login(BaseSecurityRenderer):
 
             # Terms of Service
             if request.path not in ["/api/v4/help/tos/", "/api/v4/user/whoami/",
-                                    f"/api/v4/user/tos/{logged_in_uname}/"] \
+                                    f"/api/v4/user/tos/{logged_in_uname}/",
+                                    "/api/v4/auth/logout/"] \
                     and not user.get('agrees_with_tos', False) and config.ui.tos is not None:
                 abort(403, "Agree to Terms of Service before you can make any API calls")
                 return

--- a/assemblyline_ui/api/v4/service.py
+++ b/assemblyline_ui/api/v4/service.py
@@ -417,23 +417,24 @@ def set_service(servicename, **_):
     delta['version'] = version
 
     # Check if any changes we made to update_config
-    new_sources = delta['update_config']['sources']
+    new_sources = data['update_config']['sources']
     orig_sources = current_service['update_config']['sources']
-    total_sources = new_sources + orig_sources
 
     # Track success/failure
     source_added = {}
     source_removed = {}
 
-    for src in total_sources:
-        if src not in new_sources and src in orig_sources:  # Remove of signatures
-            source_removed[src['name']] = delete_signature_source(servicename, src['name']).status_code
-        elif src not in new_sources:  # Otherwise, consider additions
-            source_added[src['name']] = add_signature_source(servicename, svc_source=src).status_code
+    #Out with the old
+    for src in orig_sources:
+        source_removed[src['name']] = delete_signature_source(servicename, src['name']).status_code
+
+    #In with the new
+    for src in new_sources:
+        source_added[src['name']] = add_signature_source(servicename, svc_source=src).status_code
 
     return make_api_response({"success": STORAGE.service_delta.save(servicename, delta),
-                              "sources_added": json.dumps(source_added),
-                              "sources_removed": json.dumps(source_removed)
+                              "sources_new": json.dumps(source_added),
+                              "sources_old": json.dumps(source_removed)
                               })
 
 

--- a/assemblyline_ui/api/v4/service.py
+++ b/assemblyline_ui/api/v4/service.py
@@ -416,26 +416,29 @@ def set_service(servicename, **_):
     delta = get_recursive_delta(current_service, data)
     delta['version'] = version
 
-    # Check if any changes we made to update_config
-    new_sources = data['update_config']['sources']
-    orig_sources = current_service['update_config']['sources']
+    try:
+        # Check if any changes were made to update_config
+        new_sources = data['update_config']['sources']
+        orig_sources = current_service['update_config']['sources']
 
-    # Track success/failure
-    source_added = {}
-    source_removed = {}
+        # Track success/failure
+        source_added = {}
+        source_removed = {}
 
-    #Out with the old
-    for src in orig_sources:
-        source_removed[src['name']] = delete_signature_source(servicename, src['name']).status_code
+        #Out with the old
+        for src in orig_sources:
+            source_removed[src['name']] = delete_signature_source(servicename, src['name']).status_code
 
-    #In with the new
-    for src in new_sources:
-        source_added[src['name']] = add_signature_source(servicename, svc_source=src).status_code
+        #In with the new
+        for src in new_sources:
+            source_added[src['name']] = add_signature_source(servicename, svc_source=src).status_code
 
-    return make_api_response({"success": STORAGE.service_delta.save(servicename, delta),
-                              "sources_new": json.dumps(source_added),
-                              "sources_old": json.dumps(source_removed)
-                              })
+        return make_api_response({"success": STORAGE.service_delta.save(servicename, delta),
+                                  "sources_new": json.dumps(source_added),
+                                  "sources_old": json.dumps(source_removed)
+                                  })
+    except TypeError:
+        return make_api_response({"success": STORAGE.service_delta.save(servicename, delta)})
 
 
 @service_api.route("/update/", methods=["PUT"])

--- a/assemblyline_ui/api/v4/service.py
+++ b/assemblyline_ui/api/v4/service.py
@@ -428,7 +428,7 @@ def set_service(servicename, **_):
     for src in total_sources:
         if src not in new_sources and src in orig_sources:  # Remove of signatures
             source_removed[src['name']] = delete_signature_source(servicename, src['name']).status_code
-        else:  # Otherwise, consider additions
+        elif src not in new_sources:  # Otherwise, consider additions
             source_added[src['name']] = add_signature_source(servicename, svc_source=src).status_code
 
     return make_api_response({"success": STORAGE.service_delta.save(servicename, delta),

--- a/assemblyline_ui/api/v4/service.py
+++ b/assemblyline_ui/api/v4/service.py
@@ -419,7 +419,7 @@ def set_service(servicename, **_):
     # Check if any changes we made to update_config
     new_sources = delta['update_config']['sources']
     orig_sources = current_service['update_config']['sources']
-    total_sources = set(new_sources + orig_sources)
+    total_sources = new_sources + orig_sources
 
     # Track success/failure
     source_added = {}
@@ -427,9 +427,9 @@ def set_service(servicename, **_):
 
     for src in total_sources:
         if src not in new_sources and src in orig_sources:  # Remove of signatures
-            source_removed[f"{src['name']}"] = delete_signature_source(servicename, src['name']).status_code()
+            source_removed[src['name']] = delete_signature_source(servicename, src['name']).status_code
         else:  # Otherwise, consider additions
-            source_added[f"{src['name']}"] = add_signature_source(servicename, request=src).status_code()
+            source_added[src['name']] = add_signature_source(servicename, svc_source=src).status_code
 
     return make_api_response({"success": STORAGE.service_delta.save(servicename, delta),
                               "sources_added": json.dumps(source_added),

--- a/assemblyline_ui/api/v4/signature.py
+++ b/assemblyline_ui/api/v4/signature.py
@@ -204,6 +204,9 @@ def add_signature_source(service, svc_source=None, **_):
                                  err="Invalid source object data",
                                  status_code=400)
 
+    # Validate that the source name given doesn't include spaces
+    data['name'] = str(data['name']).replace(" ", "_")
+
     service_data = STORAGE.get_service_with_delta(service, as_obj=False)
     if not service_data.get('update_config', {}).get('generates_signatures', False):
         return make_api_response({"success": False},

--- a/assemblyline_ui/api/v4/signature.py
+++ b/assemblyline_ui/api/v4/signature.py
@@ -170,7 +170,7 @@ def add_update_many_signature(**_):
 
 @signature_api.route("/sources/<service>/", methods=["PUT"])
 @api_login(audit=False, required_priv=['W'], allow_readonly=False, require_type=['admin', 'signature_manager'])
-def add_signature_source(service, **_):
+def add_signature_source(service, svc_source=None, **_):
     """
     Add a signature source for a given service
 
@@ -196,8 +196,9 @@ def add_signature_source(service, **_):
     Result example:
     {"success": True/False}   # if the operation succeeded of not
     """
+
     try:
-        data = request.json
+        data = svc_source if svc_source else request.json
     except (ValueError, KeyError):
         return make_api_response({"success": False},
                                  err="Invalid source object data",
@@ -227,7 +228,8 @@ def add_signature_source(service, **_):
     _reset_service_updates(service)
 
     # Save the signature
-    return make_api_response({"success": STORAGE.service_delta.save(service, service_delta)})
+    return make_api_response({"success": STORAGE.service_delta.save(service, service_delta),
+                              "source": data})
 
 
 # noinspection PyPep8Naming

--- a/assemblyline_ui/api/v4/signature.py
+++ b/assemblyline_ui/api/v4/signature.py
@@ -228,8 +228,7 @@ def add_signature_source(service, svc_source=None, **_):
     _reset_service_updates(service)
 
     # Save the signature
-    return make_api_response({"success": STORAGE.service_delta.save(service, service_delta),
-                              "source": data})
+    return make_api_response({"success": STORAGE.service_delta.save(service, service_delta)})
 
 
 # noinspection PyPep8Naming


### PR DESCRIPTION
Relating to [Deleting source from "Services" doesn't work](https://cccs.atlassian.net/browse/AL-716)

Forced update of the services' sources requires a change to the update_interval to 60s minimum in the UI to trigger the updater service to react to the change more timely. Don't know if it's possible to force it from within the UI service.

Outputs the old sources and the new/current sources to be used by the service and signature management.

Relating to [I believe a space in the source field of signature sources break the YARA updater](https://cccs.atlassian.net/browse/AL-737)
Applied the change to signature.py since this could apply to any service using signature sources