### PR TITLE
Add/Remove signatures from Services

### DIFF
--- a/assemblyline_ui/api/base.py
+++ b/assemblyline_ui/api/base.py
@@ -93,7 +93,8 @@ class api_login(BaseSecurityRenderer):
             user = login(logged_in_uname)
 
             # Terms of Service
-            if not request.path == "/api/v4/user/tos/%s/" % logged_in_uname \
+            if request.path not in ["/api/v4/help/tos/", "/api/v4/user/whoami/",
+                                    f"/api/v4/user/tos/{logged_in_uname}/"] \
                     and not user.get('agrees_with_tos', False) and config.ui.tos is not None:
                 abort(403, "Agree to Terms of Service before you can make any API calls")
                 return

--- a/assemblyline_ui/api/base.py
+++ b/assemblyline_ui/api/base.py
@@ -94,7 +94,8 @@ class api_login(BaseSecurityRenderer):
 
             # Terms of Service
             if request.path not in ["/api/v4/help/tos/", "/api/v4/user/whoami/",
-                                    f"/api/v4/user/tos/{logged_in_uname}/"] \
+                                    f"/api/v4/user/tos/{logged_in_uname}/",
+                                    "/api/v4/auth/logout/"] \
                     and not user.get('agrees_with_tos', False) and config.ui.tos is not None:
                 abort(403, "Agree to Terms of Service before you can make any API calls")
                 return

--- a/assemblyline_ui/api/v4/service.py
+++ b/assemblyline_ui/api/v4/service.py
@@ -419,8 +419,7 @@ def set_service(servicename, **_):
     removed_sources = {}
     # Check sources, especially to remove old sources
     if delta.get("update_config", None):
-        delta['update_config']['sources'] = data['update_config']['sources']
-        current_sources = STORAGE.get_service_with_delta(servicename, as_obj=False)['update_config']['sources']
+        current_sources = STORAGE.get_service_with_delta(servicename, as_obj=False).get('update_config', {}).get('sources', [])
         for source in current_sources:
             if source not in delta['update_config']['sources']:
                 removed_sources[source['name']] = STORAGE.signature.delete_matching(f"type:{servicename.lower()} AND source:{source['name']}")

--- a/assemblyline_ui/api/v4/service.py
+++ b/assemblyline_ui/api/v4/service.py
@@ -420,28 +420,21 @@ def set_service(servicename, **_):
 
         # Need to know what the service is currently using to see what got removed
         data_sources = data['update_config']['sources']
+        service_delta = STORAGE.service_delta.get(servicename, as_obj=False)
         svc_delta_sources = STORAGE.service_delta.get(servicename, as_obj=False)['update_config']['sources']
 
         sources = {x['name']: x
                    for x in svc_delta_sources + data_sources}.values()
 
-        # Track success/failure/already exists
-        source_added = {}
-        source_removed = {}
-
         for source in sources:
             if source in data_sources:
                 # Add
-                source_added[source['name']] = add_signature_source_function(servicename, source).status_code
+                add_signature_source_function(servicename, source, service_delta)
             else:
                 # Remove
-                source_removed[source['name']] = delete_signature_source_function(servicename,
-                                                                                  source['name']).status_code
+                delete_signature_source_function(servicename, source['name'], service_delta)
 
-        return make_api_response({"success": STORAGE.service_delta.save(servicename, delta),
-                                  "sources_added": source_added,
-                                  "sources_removed": source_removed
-                                  })
+        return make_api_response({"success": STORAGE.service_delta.save(servicename, service_delta)})
     except:
         return make_api_response({"success": STORAGE.service_delta.save(servicename, delta)})
 

--- a/assemblyline_ui/api/v4/service.py
+++ b/assemblyline_ui/api/v4/service.py
@@ -10,9 +10,8 @@ from assemblyline.remote.datatypes import get_client
 from assemblyline.remote.datatypes.hash import Hash
 from assemblyline_core.updater.helper import get_latest_tag_for_service
 from assemblyline_ui.api.base import api_login, make_api_response, make_subapi_blueprint
-from assemblyline_ui.config import STORAGE, LOGGER
-
 from assemblyline_ui.api.v4.signature import _reset_service_updates
+from assemblyline_ui.config import STORAGE, LOGGER
 
 config = forge.get_config()
 
@@ -419,10 +418,12 @@ def set_service(servicename, **_):
     removed_sources = {}
     # Check sources, especially to remove old sources
     if delta.get("update_config", None):
-        current_sources = STORAGE.get_service_with_delta(servicename, as_obj=False).get('update_config', {}).get('sources', [])
+        current_sources = STORAGE.get_service_with_delta(servicename, as_obj=False).get(
+            'update_config', {}).get('sources', [])
         for source in current_sources:
             if source not in delta['update_config']['sources']:
-                removed_sources[source['name']] = STORAGE.signature.delete_matching(f"type:{servicename.lower()} AND source:{source['name']}")
+                removed_sources[source['name']] = STORAGE.signature.delete_matching(
+                    f"type:{servicename.lower()} AND source:{source['name']}")
         _reset_service_updates(servicename)
 
     return make_api_response({"success": STORAGE.service_delta.save(servicename, delta),

--- a/test/test_service.py
+++ b/test/test_service.py
@@ -133,14 +133,12 @@ def test_edit_service_source(datastore, login_session):
     delta_data = ds.service_delta.search("id:*", rows=100, as_obj=False)
     svc_data = ds.service.search("id:*", rows=100, as_obj=False)
 
-    service = "Suricata"
-
     # Init
     service_conf = {
-        "name": service,
+        "name": "Suricata",
         "enabled": True,
-        "category": SERVICES[service][0],
-        "stage": SERVICES[service][1],
+        "category": "Networking",
+        "stage": "CORE",
         "version": "4.0.0",
         "docker_config": {
             "image": f"cccs/assemblyline-service-suricata:4.0.0.dev69",
@@ -164,7 +162,7 @@ def test_edit_service_source(datastore, login_session):
         }
     }
     service_data = Service(service_conf).as_primitives()
-    resp = get_api_data(session, f"{host}/api/v4/service/{service}/", method="POST", data=json.dumps(service_data))
+    resp = get_api_data(session, f"{host}/api/v4/service/Suricata/", method="POST", data=json.dumps(service_data))
     assert resp['success']
 
     ds.service_delta.commit()
@@ -183,7 +181,7 @@ def test_edit_service_source(datastore, login_session):
     }
 
     service_data = Service(service_conf).as_primitives()
-    resp = get_api_data(session, f"{host}/api/v4/service/{service}/", method="POST", data=json.dumps(service_data))
+    resp = get_api_data(session, f"{host}/api/v4/service/Suricata/", method="POST", data=json.dumps(service_data))
     assert resp['success']
 
     ds.service_delta.commit()

--- a/test/test_service.py
+++ b/test/test_service.py
@@ -1,7 +1,6 @@
 import json
 import pytest
 import random
-from time import sleep
 
 from conftest import get_api_data
 


### PR DESCRIPTION
Relating to [Deleting source from "Services" doesn't work ](https://cccs.atlassian.net/browse/AL-716):

This change allows source management to be available from the Services menu which is what caused the Suricata issue we're seeing on prod (changes weren't being reflected properly). Same issue could occur with services relying on signature sources like YARA.

@cccs-douglass mentioned it's ill-advised to interrupt changes happening with the service_delta doc by making different changes concurrently; let one finish before you start another.

In this particular instance, I needed to grab what the service's current delta was before allowing it to save the new delta, otherwise I would lose information such as the original source list which is necessary for cleaning up sources that are to be removed (current_service, delta, data don't include this information)

If there is a better way of going about it, let me know. I could perform the save right after getting the current delta if that's recommended.