### PR TITLE
Adding signature check

### DIFF
--- a/assemblyline_ui/static/js/ng-utils.js
+++ b/assemblyline_ui/static/js/ng-utils.js
@@ -865,7 +865,10 @@ utils.directive('ncSection', function () {
 
                         // adding a tool tip and message for signatures
                         let sig_section = document.createElement("div");
-                        let signature_count = Object.keys(signatures).length;
+                        let signature_count = 0;
+                        if (signatures !== undefined) {
+                            signature_count = Object.keys(signatures).length;
+                        }
 
                         if (signature_count > 0) {
                             let sig_message;


### PR DESCRIPTION
Added an if condition that is required if services submit a process dict that doesn't have the `signatures` key. It was causing an error in the UI in the present state.