### PR TITLE
Quota without error

### DIFF
--- a/assemblyline_ui/api/base.py
+++ b/assemblyline_ui/api/base.py
@@ -10,7 +10,7 @@ from assemblyline_ui.security.apikey_auth import validate_apikey
 from assemblyline_ui.security.authenticator import BaseSecurityRenderer
 from assemblyline_ui.config import BUILD_LOWER, BUILD_MASTER, BUILD_NO, LOGGER, RATE_LIMITER, STORAGE
 from assemblyline_ui.helper.user import login
-from assemblyline_ui.http_exceptions import QuotaExceededException, AuthenticationException
+from assemblyline_ui.http_exceptions import AuthenticationException
 from assemblyline_ui.config import config
 from assemblyline_ui.logger import log_with_traceback
 from assemblyline.common.str_utils import safe_str
@@ -145,7 +145,7 @@ class api_login(BaseSecurityRenderer):
                 if config.ui.enforce_quota:
                     LOGGER.info("User %s was prevented from using the api due to exceeded quota. [%s/%s]" %
                                 (quota_user, count, quota))
-                    raise QuotaExceededException("You've exceeded your maximum quota of %s " % quota)
+                    return make_api_response("", "You've exceeded your maximum quota of %s " % quota, 503)
                 else:
                     LOGGER.debug("Quota exceeded for user %s. [%s/%s]" % (quota_user, count, quota))
             else:
@@ -161,7 +161,7 @@ class api_login(BaseSecurityRenderer):
         return base
 
 
-def make_api_response(data, err="", status_code=200, cookies=None):
+def make_api_response(data, err="", status_code=200, cookies=None) -> Response:
     quota_user = flsk_session.pop("quota_user", None)
     quota_id = flsk_session.pop("quota_id", None)
     quota_set = flsk_session.pop("quota_set", False)

--- a/assemblyline_ui/api/v4/submit.py
+++ b/assemblyline_ui/api/v4/submit.py
@@ -210,9 +210,9 @@ def submit(**kwargs):
     <Submission message object as a json dictionary>
     """
     user = kwargs['user']
-    quota_response = check_submission_quota(user)
-    if quota_response:
-        return quota_response
+    quota_error = check_submission_quota(user)
+    if quota_error:
+        return make_api_response("", quota_error, 503)
 
     out_dir = os.path.join(TEMP_SUBMIT_DIR, get_random_id())
 

--- a/assemblyline_ui/api/v4/submit.py
+++ b/assemblyline_ui/api/v4/submit.py
@@ -210,8 +210,10 @@ def submit(**kwargs):
     <Submission message object as a json dictionary>
     """
     user = kwargs['user']
-    check_submission_quota(user)
-        
+    quota_response = check_submission_quota(user)
+    if quota_response:
+        return quota_response
+
     out_dir = os.path.join(TEMP_SUBMIT_DIR, get_random_id())
 
     with forge.get_filestore() as f_transport:

--- a/assemblyline_ui/api/v4/ui.py
+++ b/assemblyline_ui/api/v4/ui.py
@@ -232,7 +232,9 @@ def start_ui_submission(ui_sid, **kwargs):
     """
     user = kwargs['user']
 
-    check_submission_quota(user)
+    quota_response = check_submission_quota(user)
+    if quota_response:
+        return quota_response
 
     ui_params = request.json
     ui_params['groups'] = kwargs['user']['groups']

--- a/assemblyline_ui/api/v4/ui.py
+++ b/assemblyline_ui/api/v4/ui.py
@@ -232,9 +232,9 @@ def start_ui_submission(ui_sid, **kwargs):
     """
     user = kwargs['user']
 
-    quota_response = check_submission_quota(user)
-    if quota_response:
-        return quota_response
+    quota_error = check_submission_quota(user)
+    if quota_error:
+        return make_api_response("", quota_error, 503)
 
     ui_params = request.json
     ui_params['groups'] = kwargs['user']['groups']

--- a/assemblyline_ui/error.py
+++ b/assemblyline_ui/error.py
@@ -9,7 +9,7 @@ from werkzeug.exceptions import Forbidden, Unauthorized
 from assemblyline_ui.api.base import make_api_response
 from assemblyline_ui.config import AUDIT, AUDIT_LOG, LOGGER, config, KV_SESSION
 from assemblyline_ui.helper.views import redirect_helper
-from assemblyline_ui.http_exceptions import AccessDeniedException, QuotaExceededException, AuthenticationException
+from assemblyline_ui.http_exceptions import AccessDeniedException, AuthenticationException
 from assemblyline_ui.logger import log_with_traceback
 
 errors = Blueprint("errors", __name__)
@@ -109,9 +109,6 @@ def handle_500(e):
 
     if isinstance(e.original_exception, AuthenticationException):
         return handle_401(e.original_exception)
-
-    if isinstance(e.original_exception, QuotaExceededException):
-        return make_api_response("", str(e.original_exception), 503)
 
     oe = e.original_exception or e
 

--- a/assemblyline_ui/helper/user.py
+++ b/assemblyline_ui/helper/user.py
@@ -1,12 +1,16 @@
+from typing import Optional
+
+import flask
+
 from assemblyline.common.str_utils import safe_str
 from assemblyline.common import forge
 from assemblyline.odm.models.user import User
 from assemblyline.odm.models.user_settings import UserSettings
 from assemblyline.remote.datatypes.hash import Hash
+from assemblyline_ui.api.base import make_api_response
 from assemblyline_ui.config import LOGGER, STORAGE, CLASSIFICATION
 from assemblyline_ui.helper.service import get_default_service_spec, get_default_service_list, simplify_services
-from assemblyline_ui.http_exceptions import AccessDeniedException, InvalidDataException, QuotaExceededException, \
-    AuthenticationException
+from assemblyline_ui.http_exceptions import AccessDeniedException, InvalidDataException, AuthenticationException
 
 ACCOUNT_USER_MODIFIABLE = ["name", "avatar", "groups", "password"]
 config = forge.get_config()
@@ -43,7 +47,7 @@ def add_access_control(user):
     user['access_control'] = safe_str(query)
      
 
-def check_submission_quota(user, num=1):
+def check_submission_quota(user, num=1) -> Optional[flask.Response]:
     quota_user = user['uname']
     quota = user.get('submission_quota', 5)
     count = num + Hash('submissions-' + quota_user, **persistent).length()
@@ -52,8 +56,9 @@ def check_submission_quota(user, num=1):
             "User %s exceeded their submission quota. [%s/%s]",
             quota_user, count, quota
         )
-        raise QuotaExceededException("You've exceeded your maximum submission quota of %s " % quota)
-        
+        return make_api_response("", "You've exceeded your maximum submission quota of %s " % quota, 503)
+    return None
+
 
 def create_menu(user, path):
     user['groups'].insert(0, "ALL")

--- a/assemblyline_ui/helper/user.py
+++ b/assemblyline_ui/helper/user.py
@@ -1,13 +1,10 @@
 from typing import Optional
 
-import flask
-
 from assemblyline.common.str_utils import safe_str
 from assemblyline.common import forge
 from assemblyline.odm.models.user import User
 from assemblyline.odm.models.user_settings import UserSettings
 from assemblyline.remote.datatypes.hash import Hash
-from assemblyline_ui.api.base import make_api_response
 from assemblyline_ui.config import LOGGER, STORAGE, CLASSIFICATION
 from assemblyline_ui.helper.service import get_default_service_spec, get_default_service_list, simplify_services
 from assemblyline_ui.http_exceptions import AccessDeniedException, InvalidDataException, AuthenticationException
@@ -47,7 +44,7 @@ def add_access_control(user):
     user['access_control'] = safe_str(query)
      
 
-def check_submission_quota(user, num=1) -> Optional[flask.Response]:
+def check_submission_quota(user, num=1) -> Optional[str]:
     quota_user = user['uname']
     quota = user.get('submission_quota', 5)
     count = num + Hash('submissions-' + quota_user, **persistent).length()
@@ -56,7 +53,7 @@ def check_submission_quota(user, num=1) -> Optional[flask.Response]:
             "User %s exceeded their submission quota. [%s/%s]",
             quota_user, count, quota
         )
-        return make_api_response("", "You've exceeded your maximum submission quota of %s " % quota, 503)
+        return "You've exceeded your maximum submission quota of %s " % quota
     return None
 
 

--- a/assemblyline_ui/http_exceptions.py
+++ b/assemblyline_ui/http_exceptions.py
@@ -10,9 +10,5 @@ class InvalidDataException(Exception):
     pass
 
 
-class QuotaExceededException(Exception):
-    pass
-
-
 class AuthenticationException(Exception):
     pass

--- a/test/test_submit.py
+++ b/test/test_submit.py
@@ -60,7 +60,7 @@ def test_resubmit_dynamic(datastore, login_session):
     assert resp['sid'] != submission.sid
     for f in resp['files']:
         assert f['sha256'] == sha256
-    assert resp['params']['services']['resubmit'] == ['Dynamic Analysis']
+    assert 'Dynamic Analysis' in resp['params']['services']['selected']
 
     msg = SubmissionTask(sq.pop(blocking=False))
     assert msg.submission.sid == resp['sid']


### PR DESCRIPTION
Letting flask catch an exception for us is always logged as an error.

A quota restriction isn't an error, to prevent it from being treated that way I've changed the places where we do quota checks to handle it with the same API response the exception would have created.