### PR TITLE
The multiple_keys API should build the section_hierarchy

### DIFF
--- a/assemblyline_ui/api/v4/result.py
+++ b/assemblyline_ui/api/v4/result.py
@@ -54,7 +54,8 @@ def get_multiple_service_results(**kwargs):
 
     for r_key in list(results.keys()):
         r_value = format_result(user['classification'], results[r_key],
-                                file_infos.get(r_key[:64], {}).get('classification', CLASSIFICATION.UNRESTRICTED))
+                                file_infos.get(r_key[:64], {}).get('classification', CLASSIFICATION.UNRESTRICTED),
+                                build_hierarchy=True)
         if not r_value:
             del results[r_key]
         else:


### PR DESCRIPTION
The section hierarchy is missing from the multiples_keys API which is causing a less optimal rendering method. This will force the section_hierarchy to be generated.