### PR TITLE
Add support for Azure AD B2C

### DIFF
--- a/assemblyline_ui/app.py
+++ b/assemblyline_ui/app.py
@@ -87,11 +87,24 @@ if config.config.auth.oauth.enabled:
     providers = []
     for name, p in config.config.auth.oauth.providers.items():
         p = p.as_primitives()
-        p.pop('auto_create', None)
-        p.pop('auto_sync', None)
-        p.pop('user_get', None)
-        p['name'] = name
         if p['client_id'] and p['client_secret']:
+            # Set provider name
+            p['name'] = name
+
+            # Remove AL specific fields
+            p.pop('auto_create', None)
+            p.pop('auto_sync', None)
+            p.pop('user_get', None)
+            p.pop('auto_properties', None)
+            p.pop('uid_field', None)
+            p.pop('uid_regex', None)
+            p.pop('uid_format', None)
+            p.pop('user_groups', None)
+            p.pop('user_groups_data_field', None)
+            p.pop('user_groups_name_field', None)
+            p.pop('app_provider', None)
+
+            # Add the provider to the list of providers
             providers.append(p)
 
     if providers:


### PR DESCRIPTION
Allow oauth provider to use a client_credential type grant to query user and groups APIs. This allows Azure B2C user to be able to login using a B2C oauth tenant URI.