### PR TITLE
PROD: Enable auditing at the INFO level, don't follow log_level

### DIFF
--- a/assemblyline_ui/config.py
+++ b/assemblyline_ui/config.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import functools
-    
+
 from assemblyline.common import version
 from assemblyline.common.logformat import AL_LOG_FORMAT
 from assemblyline.common import forge, log as al_log
@@ -118,6 +118,9 @@ AUDIT_KW_TARGET = ["sid",
 
 AUDIT_LOG = logging.getLogger('assemblyline.ui.audit')
 LOGGER = logging.getLogger('assemblyline.ui')
+
+if AUDIT:
+    AUDIT_LOG.setLevel(logging.INFO)
 
 if DEBUG:
     if not os.path.exists(config.logging.log_directory):


### PR DESCRIPTION
Tested and working on Rancher deployment; only audit logs are visible at the INFO level, other logs are visible at the defined logging level in the config. https://cccs.atlassian.net/browse/AL-1052

log_level=WARNING:
![image](https://user-images.githubusercontent.com/62077998/108245860-c996e880-711e-11eb-8202-86b39f28680a.png)

