### PR TITLE
Allow AL to disable signatures when they've become deprecated

### DIFF
--- a/assemblyline_ui/api/v4/signature.py
+++ b/assemblyline_ui/api/v4/signature.py
@@ -92,8 +92,8 @@ def add_update_signature(**_):
             return make_api_response({"success": True, "id": key})
 
         # If rule has been deprecated/disabled after initial deployment, then disable it
-        if not (rule['status'] != old['status'] and rule['status'] == "DISABLED"):
-            rule['status'] = old['status']
+        if not (data['status'] != old['status'] and data['status'] == "DISABLED"):
+            data['status'] = old['status']
         data['state_change_date'] = old['state_change_date']
         data['state_change_user'] = old['state_change_user']
 

--- a/assemblyline_ui/api/v4/signature.py
+++ b/assemblyline_ui/api/v4/signature.py
@@ -91,7 +91,9 @@ def add_update_signature(**_):
         if old['data'] == data['data']:
             return make_api_response({"success": True, "id": key})
 
-        data['status'] = old['status']
+        # If rule has been deprecated/disabled after initial deployment, then disable it
+        if not (rule['status'] != old['status'] and rule['status'] == "DISABLED"):
+            rule['status'] = old['status']
         data['state_change_date'] = old['state_change_date']
         data['state_change_user'] = old['state_change_user']
 
@@ -156,7 +158,9 @@ def add_update_many_signature(**_):
     for rule in data:
         key = f"{rule['type']}_{rule['source']}_{rule.get('signature_id', rule['name'])}"
         if key in old_data:
-            rule['status'] = old_data[key]['status']
+            # If rule has been deprecated/disabled after initial deployment, then disable it
+            if not (rule['status'] != old_data[key]['status'] and rule['status'] == "DISABLED"):
+                rule['status'] = old_data[key]['status']
             rule['state_change_date'] = old_data[key]['state_change_date']
             rule['state_change_user'] = old_data[key]['state_change_user']
 


### PR DESCRIPTION
Relating to: https://cccs.atlassian.net/browse/AL-792

TL;DR: AL is doing the right thing by disabling signatures that are deprecated when they're first added. However, if a rule becomes deprecated after initial deployment, AL retains it's original state which isn't desirable (at least in the case for YARA).

This will allow AL to place the rule in a disabled state, which can be removed later on.