### PR TITLE
DEV: Update all classification of signatures

### DIFF
--- a/assemblyline_ui/api/v4/service.py
+++ b/assemblyline_ui/api/v4/service.py
@@ -13,6 +13,7 @@ from assemblyline_ui.api.base import api_login, make_api_response, make_subapi_b
 from assemblyline_ui.api.v4.signature import _reset_service_updates
 from assemblyline_ui.config import STORAGE, LOGGER
 
+Classification = forge.get_classification()
 config = forge.get_config()
 
 SUB_API = 'service'
@@ -45,9 +46,10 @@ def check_for_source_change(delta_list, source):
         if delta['name'] == source['name']:
             # Classification update
             if delta['default_classification'] != source['default_classification']:
+                class_norm = Classification.normalize_classification(delta['default_classification'])
                 change_list['default_classification'] = STORAGE.signature.update_by_query(
-                    query=f"source: {source['name']}",
-                    operations=[("SET", "classification", delta['default_classification'])])
+                    query=f'source:"{source["name"]}"',
+                    operations=[("SET", "classification", class_norm)])
 
     return change_list
 
@@ -459,7 +461,7 @@ def set_service(servicename, **_):
                     # If not a minor change, then assume change is drastically different (ie. removal)
                     if not check_for_source_change(delta['update_config']['sources'], source):
                         removed_sources[source['name']] = \
-                            STORAGE.signature.delete_matching(f"type:{servicename.lower()} AND source:{source['name']}")
+                            STORAGE.signature.delete_matching(f'type:"{servicename.lower()}" AND source:"{source["name"]}"')
             _reset_service_updates(servicename)
 
     return make_api_response({"success": STORAGE.service_delta.save(servicename, delta),

--- a/assemblyline_ui/api/v4/signature.py
+++ b/assemblyline_ui/api/v4/signature.py
@@ -401,7 +401,7 @@ def delete_signature_source(service, name, **_):
     success = STORAGE.service_delta.save(service, service_delta)
     if success:
         # Remove old source signatures
-        STORAGE.signature.delete_matching(f"type:{service.lower()} AND source:{name}")
+        STORAGE.signature.delete_matching(f'type:"{service.lower()}" AND source:"{name}"')
 
     _reset_service_updates(service)
 
@@ -640,8 +640,9 @@ def update_signature_source(service, name, **_):
 
     # Has the classification changed?
     if classification_changed:
-        STORAGE.signature.update_by_query(query=f"source: {data['name']}",
-                                          operations=[("SET", "classification", data['default_classification'])])
+        class_norm = Classification.normalize_classification(data['default_classification'])
+        STORAGE.signature.update_by_query(query=f'source:"{data["name"]}"',
+                                          operations=[("SET", "classification", class_norm)])
 
     _reset_service_updates(service)
 

--- a/assemblyline_ui/api/v4/signature.py
+++ b/assemblyline_ui/api/v4/signature.py
@@ -618,10 +618,12 @@ def update_signature_source(service, name, **_):
 
     new_sources = []
     found = False
+    classification_changed = False
     for source in current_sources:
         if data['name'] == source['name']:
             new_sources.append(data)
             found = True
+            classification_changed = data['default_classification'] != source['default_classification']
         else:
             new_sources.append(source)
 
@@ -635,6 +637,11 @@ def update_signature_source(service, name, **_):
         service_delta['update_config'] = {"sources": new_sources}
     else:
         service_delta['update_config']['sources'] = new_sources
+
+    # Has the classification changed?
+    if classification_changed:
+        STORAGE.signature.update_by_query(query=f"source: {data['name']}",
+                                          operations=[("SET", "classification", data['default_classification'])])
 
     _reset_service_updates(service)
 


### PR DESCRIPTION
Relating to: https://cccs.atlassian.net/browse/AL-1089 (1)
_"Changing the signature source classification only applies to new rules when it should apply to all in the ruleset"_

Changes made via the UI/API in regards to signature source classification will apply to all signatures already loaded into AL as well as any new ones (not just new ones only)