### PR TITLE
hotfix/gunicorn_workers (dev)

### DIFF
--- a/assemblyline_ui/gunicorn_config.py
+++ b/assemblyline_ui/gunicorn_config.py
@@ -5,3 +5,4 @@ import multiprocessing
 bind = f":{int(env.get('PORT', 5000))}"
 workers = int(env.get('WORKERS', multiprocessing.cpu_count()))
 threads = int(env.get('THREADS', 4))
+max_requests = int(env.get('MAX_REQUESTS', '1000'))


### PR DESCRIPTION
Restart workers after 1000 requests to limit memory creeping