### PR TITLE
Disable service if considered incompatible

### DIFF
--- a/assemblyline_ui/api/v4/service.py
+++ b/assemblyline_ui/api/v4/service.py
@@ -106,7 +106,8 @@ def add_service(**_):
             tmp_service.pop('file_required', None)
             tmp_service.pop('heuristics', [])
             tmp_service['update_channel'] = config.services.preferred_update_channel
-            image_name, tag_name, _ = get_latest_tag_for_service(Service(tmp_service), config, LOGGER)
+            _, tag_name, _ = get_latest_tag_for_service(Service(tmp_service), config, LOGGER)
+            enable_allowed = bool(tag_name)
             if tag_name:
                 tag_name = tag_name.encode()
             else:
@@ -132,6 +133,7 @@ def add_service(**_):
 
         # Fix update_channel with the system default
         service['update_channel'] = config.services.preferred_update_channel
+        service['enabled'] = service['enabled'] and enable_allowed
 
         # Load service info
         service = Service(service)


### PR DESCRIPTION
Will allow service manifests to be loaded but the API will decide to keep the service enabled/disabled based on compatibility condition.