### PR TITLE
Delete updater hash when service is removed

### DIFF
--- a/assemblyline_ui/api/v4/service.py
+++ b/assemblyline_ui/api/v4/service.py
@@ -572,6 +572,13 @@ def remove_service(servicename, **_):
             'name': servicename
         })
 
+        # Clear potentially unused keys from Redis related to service
+        Hash(f'service-updates-{servicename}', get_client(
+            host=config.core.redis.persistent.host,
+            port=config.core.redis.persistent.port,
+            private=False,
+        )).delete()
+
         return make_api_response({"success": success})
     else:
         return make_api_response({"success": False},


### PR DESCRIPTION
Absence of change leave service updaters to believe an update exists in the system when there isn't.

Occurs if you add a service (ie. YARA), let an update pass for the first time, remove service and re-add service.