### PR TITLE
update test_user to reflect changes made to get_dynamic_classification

### DIFF
--- a/test/test_user.py
+++ b/test/test_user.py
@@ -5,7 +5,7 @@ import random
 from conftest import APIError, get_api_data
 
 from assemblyline.common.forge import get_classification
-from assemblyline_ui.helper.user import load_user_settings, get_dynamic_classification
+from assemblyline_ui.helper.user import load_user_settings
 from assemblyline.odm.models.user import User
 from assemblyline.odm.models.user_favorites import Favorite, UserFavorites
 from assemblyline.odm.randomizer import random_model_obj

--- a/test/test_user.py
+++ b/test/test_user.py
@@ -95,8 +95,10 @@ def test_add_user(datastore, login_session):
     datastore.user.commit()
     new_user = datastore.user.get(username, as_obj=False)
 
-    # submission through api applies `get_dynamic_classification`s which can modify the groups
-    u['classification'] = get_dynamic_classification(u['classification'], u)
+    # submission through api applies `get_dynamic_classification`s which normalizes with `get_dynamic_groups=False`
+    new_user['classification'] = CLASSIFICATION.normalize_classification(
+        new_user['classification'], get_dynamic_groups=False)
+    u['classification'] = CLASSIFICATION.normalize_classification(u['classification'], get_dynamic_groups=False)
     assert new_user == u
 
 
@@ -234,11 +236,10 @@ def test_set_user(datastore, login_session):
         u.pop(k)
         new_user.pop(k)
 
-    # Normalize classification
-    new_user['classification'] = CLASSIFICATION.normalize_classification(new_user['classification'])
-    # submission through api applies `get_dynamic_classification`s which can modify the groups
-    u['classification'] = get_dynamic_classification(u['classification'], u)
-    u['classification'] = CLASSIFICATION.normalize_classification(u['classification'])
+    # submission through api applies `get_dynamic_classification`s which normalizes with `get_dynamic_groups=False`
+    new_user['classification'] = CLASSIFICATION.normalize_classification(
+        new_user['classification'], get_dynamic_groups=False)
+    u['classification'] = CLASSIFICATION.normalize_classification(u['classification'], get_dynamic_groups=False)
 
     for k in u.keys():
         assert u[k] == new_user[k]


### PR DESCRIPTION
Changes made in https://github.com/CybercentreCanada/assemblyline-ui/commit/1872c9942d6854453555f296eae46fa5bc8ae7e5 to `get_dynamic_classification` can modify the group due to the added call to `normalize_classification`.

Due to the random data used in the `test_user` tests, this could sometimes generate a classification that would be modified, and sometime a classification that would not, causing tests to fail sometimes and not others.
(eg: TLP:CLEAR//REL TO CCCS --> TLP:CLEAR//REL TO CSE/CCCS)

I assume this it not an unintended bug with the `get_dynamic_classification` function and it just needs tests updated.