### PR TITLE
get_dynamic_classification should skip auto selecting groups (master)

### DIFF
--- a/assemblyline_ui/helper/user.py
+++ b/assemblyline_ui/helper/user.py
@@ -129,7 +129,7 @@ def save_user_account(username, data, user):
 
 
 def get_dynamic_classification(current_c12n, user_info):
-    new_c12n = Classification.normalize_classification(current_c12n, get_dynamic_groups=False)
+    new_c12n = Classification.normalize_classification(current_c12n, skip_auto_select=True, get_dynamic_groups=False)
 
     if Classification.dynamic_groups:
         email = user_info.get('email', None)


### PR DESCRIPTION
When normalizing dynamic classifications for users, `skip_auto_select` should be set so that users are not given groups they should not have.