### PR TITLE
ensure correct quoting of tags.

### DIFF
--- a/assemblyline_ui/api/v4/hash_search.py
+++ b/assemblyline_ui/api/v4/hash_search.py
@@ -2,6 +2,8 @@ import concurrent.futures
 import os
 import re
 
+from urllib import parse as ul
+
 from flask import request
 from requests import Session
 
@@ -126,7 +128,8 @@ def get_external_details(
         return result
 
     # perform the lookup, ensuring access controls are applied
-    url = f"{source.url}/details/{hash_type}/{file_hash}"
+    encoded = ul.quote(ul.quote(file_hash, safe=""), safe="")
+    url = f"{source.url}/details/{hash_type}/{encoded}/"
     rsp = session.get(url, params=params, headers=headers)
 
     status_code = rsp.status_code

--- a/plugins/external_lookup/assemblyline_lookup/app.py
+++ b/plugins/external_lookup/assemblyline_lookup/app.py
@@ -5,6 +5,8 @@ import concurrent.futures
 import json
 import os
 
+from urllib import parse as ul
+
 import requests
 
 from flask import Flask, Response, jsonify, make_response, request
@@ -99,10 +101,13 @@ def lookup_tag(tag_name: str, tag: str, limit: int = 25, timeout: float = 3.0):
     return rsp_json["api_response"]
 
 
-@app.route("/search/<tag_name>/<path:tag>/", methods=["GET"])
+@app.route("/search/<tag_name>/<tag>/", methods=["GET"])
 def search_tag(tag_name: str, tag: str):
     """Lookup tags from upstream/downstream assemblyline
 
+    Variables:
+    tag_name => Tag to look up in the external system.
+    tag => Tag value to lookup. *Must be double URL encoded.*
     Tag values submitted must be URL encoded.
 
     Arguments: (optional)
@@ -117,6 +122,7 @@ def search_tag(tag_name: str, tag: str):
             "classification": <classification of search>,  # Should this be the max
         }
     """
+    tag = ul.unquote(ul.unquote(tag))
     tn = TAG_MAPPING.get(tag_name)
     if tn is None:
         return make_api_response(

--- a/plugins/external_lookup/malware_bazaar/app.py
+++ b/plugins/external_lookup/malware_bazaar/app.py
@@ -4,6 +4,8 @@
 import json
 import os
 
+from urllib import parse as ul
+
 import requests
 
 from flask import Flask, Response, jsonify, make_response, request
@@ -108,9 +110,13 @@ def _row(group, name, value, name_description="", value_description=""):
     }
 
 
-@app.route("/details/<tag_name>/<path:tag>/", methods=["GET"])
+@app.route("/details/<tag_name>/<tag>/", methods=["GET"])
 def tag_details(tag_name: str, tag: str) -> Response:
     """Get detailed lookup results from Malware Bazaar
+
+    Variables:
+    tag_name => Tag to look up in the external system.
+    tag => Tag value to lookup. *Must be double URL encoded.*
 
     Query Params:
     max_timeout => Maximum execution time for the call in seconds
@@ -138,6 +144,7 @@ def tag_details(tag_name: str, tag: str) -> Response:
         ...,
     ]
     """
+    tag = ul.unquote(ul.unquote(tag))
     # Invalid tags must either be ignored, or return a 422
     tn = TAG_MAPPING.get(tag_name)
     if tn is None:

--- a/plugins/external_lookup/malware_bazaar/test_app.py
+++ b/plugins/external_lookup/malware_bazaar/test_app.py
@@ -1,7 +1,14 @@
+from urllib import parse as ul
+
 import pytest
 import requests
 
 from .app import app, CLASSIFICATION, TAG_MAPPING
+
+
+def dquote(tag):
+    """Double encode the tag."""
+    return ul.quote(ul.quote(tag, safe=""), safe="")
 
 
 @pytest.fixture()
@@ -119,7 +126,7 @@ def test_hash_found(test_client, mock_lookup_exists):
     digest = "7de2c1bf58bce09eecc70476747d88a26163c3d6bb1d85235c24a558d1f16754"
     mock_lookup_exists(sha256_hash=digest)
 
-    rsp = test_client.get(f"/details/sha256/{digest}/", query_string={"nodata": True})
+    rsp = test_client.get(f"/details/sha256/{dquote(digest)}/", query_string={"nodata": True})
     expected = {
         "api_error_message": "",
         "api_response": [
@@ -152,7 +159,7 @@ def test_hash_dne(test_client, mocker):
     mock_session = mocker.patch.object(requests, "Session", autospec=True)
     mock_session.return_value.post.return_value = mock_response
 
-    rsp = test_client.get(f"/details/md5/{digest}/", query_string={"nodata": True})
+    rsp = test_client.get(f"/details/md5/{dquote(digest)}/", query_string={"nodata": True})
     expected = {
         "api_error_message": "No results.",
         "api_response": None,
@@ -172,7 +179,7 @@ def test_error_conditions(test_client, mocker):
     mock_session = mocker.patch.object(requests, "Session", autospec=True)
     mock_session.return_value.post.return_value = mock_response
 
-    rsp = test_client.get(f"/details/md5/{'a' * 32}/", query_string={"nodata": True})
+    rsp = test_client.get(f"/details/md5/{dquote('a' * 32)}/", query_string={"nodata": True})
     expected = {
         "api_error_message": "Unknown error submitting data to upstream.",
         "api_response": "Some bad response",
@@ -204,7 +211,7 @@ def test_error_conditions(test_client, mocker):
     }
     mock_session.return_value.post.return_value = mock_response
 
-    rsp = test_client.get(f"/details/md5/{'a' * 32}/")
+    rsp = test_client.get(f"/details/md5/{dquote('a' * 32)}/")
     expected = {
         "api_error_message": "no_hash_provided",
         "api_response": None,
@@ -230,7 +237,7 @@ def test_imphash_found(test_client, mock_lookup_exists):
         },
     )
 
-    rsp = test_client.get(f"/details/file.pe.imports.imphash/{imphash}/", query_string={"nodata": True})
+    rsp = test_client.get(f"/details/file.pe.imports.imphash/{dquote(imphash)}/", query_string={"nodata": True})
     expected = {
         "api_error_message": "",
         "api_response": [
@@ -255,7 +262,7 @@ def test_hash_details(test_client, mock_lookup_exists):
     digest = "7de2c1bf58bce09eecc70476747d88a26163c3d6bb1d85235c24a558d1f16754"
     mock_lookup_exists(sha256_hash=digest)
 
-    rsp = test_client.get(f"/details/sha256/{digest}/")
+    rsp = test_client.get(f"/details/sha256/{dquote(digest)}/")
     expected = {
         "api_error_message": "",
         "api_response": [
@@ -339,7 +346,7 @@ def test_tag_details(test_client, mock_lookup_exists):
         },
     )
 
-    rsp = test_client.get(f"/details/file.pe.imports.imphash/{data[0]['imphash']}/")
+    rsp = test_client.get(f"/details/file.pe.imports.imphash/{dquote(data[0]['imphash'])}/")
     expected = {
         "api_error_message": "",
         "api_response": [

--- a/plugins/external_lookup/template/app.py
+++ b/plugins/external_lookup/template/app.py
@@ -11,6 +11,8 @@ To allow for extended use by non-AL systems, these tag mappings should also be c
 import json
 import os
 
+from urllib import parse as ul
+
 from flask import Flask, Response, jsonify, make_response, request
 
 app = Flask(__name__)
@@ -46,9 +48,13 @@ def get_tag_names() -> Response:
     return make_api_response(sorted(TAG_MAPPING))
 
 
-@app.route("/details/<tag_name>/<path:tag>/", methods=["GET"])
+@app.route("/details/<tag_name>/<tag>/", methods=["GET"])
 def tag_details(tag_name: str, tag: str) -> Response:
     """Define how to search for detailed tag results.
+
+    Variables:
+    tag_name => Tag to look up in the external system.
+    tag => Tag value to lookup. *Must be double URL encoded.*
 
     Query Params:
     max_timeout => Maximum execution time for the call in seconds
@@ -76,6 +82,7 @@ def tag_details(tag_name: str, tag: str) -> Response:
         ...,
     ]
     """
+    tag = ul.unquote(ul.unquote(tag))
     # Invalid tags must either be ignored, or return a 422
     tn = TAG_MAPPING.get(tag_name)
     if tn is None:

--- a/plugins/external_lookup/virustotal/app.py
+++ b/plugins/external_lookup/virustotal/app.py
@@ -96,9 +96,13 @@ def lookup_tag(tag_name: str, tag: str, timeout: float):
     return rsp.json().get("data", {})
 
 
-@app.route("/details/<tag_name>/<path:tag>/", methods=["GET"])
+@app.route("/details/<tag_name>/<tag>/", methods=["GET"])
 def tag_details(tag_name: str, tag: str) -> Response:
     """Get detailed lookup results from VirusTotal
+
+    Variables:
+    tag_name => Tag to look up in the external system.
+    tag => Tag value to lookup. *Must be double URL encoded.*
 
     Query Params:
     max_timeout => Maximum execution time for the call in seconds
@@ -126,6 +130,7 @@ def tag_details(tag_name: str, tag: str) -> Response:
         ...,
     ]
     """
+    tag = ul.unquote(ul.unquote(tag))
     # Invalid tags must either be ignored, or return a 422
     tn = TAG_MAPPING.get(tag_name)
     if tn is None:

--- a/plugins/external_lookup/virustotal/test_app.py
+++ b/plugins/external_lookup/virustotal/test_app.py
@@ -6,6 +6,10 @@ import requests
 from . import app as server
 
 
+def dquote(tag):
+    """Double encode the tag."""
+    return ul.quote(ul.quote(tag, safe=""), safe="")
+
 @pytest.fixture()
 def test_client():
     """generate a test client."""
@@ -73,7 +77,7 @@ def test_tag_found(test_client, mock_lookup_exists):
     mock_lookup_exists()
     # hash
     digest = "a" * 64
-    rsp = test_client.get(f"/details/sha1/{digest}/", query_string={"nodata": True})
+    rsp = test_client.get(f"/details/sha1/{dquote(digest)}/", query_string={"nodata": True})
     expected = {
         "api_error_message": "",
         "api_response": [
@@ -94,7 +98,7 @@ def test_tag_found(test_client, mock_lookup_exists):
 
     # ip ioc
     ip_address = "127.0.0.1"
-    rsp = test_client.get(f"/details/network.dynamic.ip/{ip_address}/", query_string={"nodata": True})
+    rsp = test_client.get(f"/details/network.dynamic.ip/{dquote(ip_address)}/", query_string={"nodata": True})
     expected = {
         "api_error_message": "",
         "api_response": [
@@ -115,8 +119,7 @@ def test_tag_found(test_client, mock_lookup_exists):
 
     # url ioc - quoted
     url = "https://a.bad.url/contains+and/a space/in-path"
-    quoted = ul.quote(url)
-    rsp = test_client.get(f"/details/network.dynamic.uri/{quoted}/", query_string={"nodata": True})
+    rsp = test_client.get(f"/details/network.dynamic.uri/{dquote(url)}/", query_string={"nodata": True})
     rsp_encoded_tag = ul.quote(ul.quote(url, safe=""), safe="")
     expected = {
         "api_error_message": "",
@@ -138,7 +141,7 @@ def test_tag_found(test_client, mock_lookup_exists):
 
     # domain ioc
     domain = "bad.domain"
-    rsp = test_client.get(f"/details/network.static.domain/{domain}/", query_string={"nodata": True})
+    rsp = test_client.get(f"/details/network.static.domain/{dquote(domain)}/", query_string={"nodata": True})
     expected = {
         "api_error_message": "",
         "api_response": [
@@ -168,7 +171,7 @@ def test_tag_dne(test_client, mocker):
     mock_session = mocker.patch.object(requests, "Session", autospec=True)
     mock_session.return_value.get.return_value = mock_response
 
-    rsp = test_client.get(f"/details/md5/{digest}/", query_string={"nodata": True})
+    rsp = test_client.get(f"/details/md5/{dquote(digest)}/", query_string={"nodata": True})
     expected = {
         "api_error_message": "No results.",
         "api_response": None,
@@ -188,7 +191,7 @@ def test_error_conditions(test_client, mocker):
     mock_session = mocker.patch.object(requests, "Session", autospec=True)
     mock_session.return_value.get.return_value = mock_response
 
-    rsp = test_client.get(f"/details/md5/{'a' * 32}/", query_string={"nodata": True})
+    rsp = test_client.get(f"/details/md5/{dquote('a' * 32)}/", query_string={"nodata": True})
     expected = {
         "api_error_message": "Error submitting data to upstream.",
         "api_response": "Some bad response",
@@ -240,7 +243,7 @@ def test_detailed_malicious(test_client, mock_lookup_exists):
     }
     mock_lookup_exists(additional_attrs=additional_attrs)
 
-    rsp = test_client.get(f"/details/sha256/{'a' * 64}/")
+    rsp = test_client.get(f"/details/sha256/{dquote('a' * 64)}/")
     expected = {
         "api_error_message": "",
         "api_response": [
@@ -344,7 +347,7 @@ def test_detailed_not_malicious(test_client, mock_lookup_exists):
         }
     )
 
-    rsp = test_client.get(f"/details/sha256/{'a' * 64}/")
+    rsp = test_client.get(f"/details/sha256/{dquote('a' * 64)}/")
     expected = {
         "api_error_message": "",
         "api_response": [
@@ -443,7 +446,7 @@ def test_detailed_enrich(test_client, mock_lookup_exists):
     }
     mock_lookup_exists(additional_attrs=additional_attrs)
 
-    rsp = test_client.get(f"/details/sha256/{'a' * 64}/")
+    rsp = test_client.get(f"/details/sha256/{dquote('a' * 64)}/")
     expected = {
         "api_error_message": "",
         "api_response": [


### PR DESCRIPTION
wsgi servers including flask will automatically unquote the url before determining the route (and remove duplicate slashes). Enforce double url encoding to ensure full urls can be submitted to exteranl services.