### PR TITLE
HSTS Support

### DIFF
--- a/assemblyline_ui/app.py
+++ b/assemblyline_ui/app.py
@@ -1,4 +1,3 @@
-
 import logging
 import os
 
@@ -43,6 +42,7 @@ from assemblyline_ui.healthz import healthz
 from assemblyline_ui import config
 
 AL_UNSECURED_UI = os.environ.get('AL_UNSECURED_UI', 'false').lower() == 'true'
+AL_HSTS_MAX_AGE = os.environ.get('AL_HSTS_MAX_AGE', None)
 CERT_BUNDLE = (
     os.environ.get('UI_CLIENT_CERT_PATH', '/etc/assemblyline/ssl/ui/tls.crt'),
     os.environ.get('UI_CLIENT_KEY_PATH', '/etc/assemblyline/ssl/ui/tls.key')
@@ -68,6 +68,19 @@ else:
 if all([os.path.exists(fp) for fp in CERT_BUNDLE]):
     # If all files required are present, start up encrypted comms
     ssl_context = CERT_BUNDLE
+    if AL_HSTS_MAX_AGE is not None:
+        try:
+            int(AL_HSTS_MAX_AGE)
+        except:
+            raise ValueError("AL_HSTS_MAX_AGE must be set to an integer")
+
+
+        def include_hsts_header(response):
+            response.headers['Strict-Transport-Security'] = f"max-age={AL_HSTS_MAX_AGE}; includeSubdomains"
+            return response
+
+
+        app.after_request(include_hsts_header)
 
 app.register_blueprint(healthz)
 app.register_blueprint(api)
@@ -101,7 +114,6 @@ app.register_blueprint(user_api)
 app.register_blueprint(webauthn_api)
 app.register_blueprint(safelist_api)
 app.register_blueprint(workflow_api)
-
 
 # Setup OAuth providers
 if config.config.auth.oauth.enabled:


### PR DESCRIPTION
Add an environment variable AL_HSTS_MAX_AGE which when set will cause assemblyline-ui to include a strict-transport-security header in all responses.

PR https://github.com/CybercentreCanada/assemblyline-helm-chart/pull/93 allows this environment variable to be set via values.yaml and also creates a serve.json in the frontend pod to configure it to include the HSTS header.

For reference see:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security