### PR TITLE
Set samesite attribute on session cookie

### DIFF
--- a/assemblyline_ui/app.py
+++ b/assemblyline_ui/app.py
@@ -1,4 +1,3 @@
-
 import logging
 import os
 
@@ -43,6 +42,7 @@ from assemblyline_ui.healthz import healthz
 from assemblyline_ui import config
 
 AL_UNSECURED_UI = os.environ.get('AL_UNSECURED_UI', 'false').lower() == 'true'
+AL_SESSION_COOKIE_SAMESITE = os.environ.get("AL_SESSION_COOKIE_SAMESITE", None)
 CERT_BUNDLE = (
     os.environ.get('UI_CLIENT_CERT_PATH', '/etc/assemblyline/ssl/ui/tls.crt'),
     os.environ.get('UI_CLIENT_KEY_PATH', '/etc/assemblyline/ssl/ui/tls.key')
@@ -65,6 +65,14 @@ else:
         SECRET_KEY=config.SECRET_KEY,
         PREFERRED_URL_SCHEME='https'
     )
+if AL_SESSION_COOKIE_SAMESITE:
+    if AL_SESSION_COOKIE_SAMESITE in ["Strict", "Lax"]:
+        app.config.update(
+            SESSION_COOKIE_SAMESITE=AL_SESSION_COOKIE_SAMESITE
+        )
+    else:
+        raise ValueError("AL_SESSION_COOKIE_SAMESITE must be set to 'Strict', 'Lax', or None")
+
 if all([os.path.exists(fp) for fp in CERT_BUNDLE]):
     # If all files required are present, start up encrypted comms
     ssl_context = CERT_BUNDLE
@@ -101,7 +109,6 @@ app.register_blueprint(user_api)
 app.register_blueprint(webauthn_api)
 app.register_blueprint(safelist_api)
 app.register_blueprint(workflow_api)
-
 
 # Setup OAuth providers
 if config.config.auth.oauth.enabled:


### PR DESCRIPTION
Add an environment variable AL_SESSION_COOKIE_SAMESITE to allow configure Flask to set the samesite attribute on the session cookie.

PR https://github.com/CybercentreCanada/assemblyline-helm-chart/pull/94 allows this environment variable to be set via values.yaml.

For reference see:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies