### PR TITLE
Allow submission of files within JSON data block

### DIFF
--- a/test/test_ingest.py
+++ b/test/test_ingest.py
@@ -178,7 +178,7 @@ def test_ingest_binary_nameless(datastore, login_session):
         msg = Submission(iq.pop(blocking=False))
         assert msg.metadata['ingest_id'] == resp['ingest_id']
         assert msg.files[0].sha256 == sha256
-        assert msg.files[0].name == sha256
+        assert msg.files[0].name == os.path.basename(temp_path)
 
     finally:
         # noinspection PyBroadException

--- a/test/test_submit.py
+++ b/test/test_submit.py
@@ -184,7 +184,7 @@ def test_submit_binary_nameless(datastore, login_session, scheduler):
         assert isinstance(resp['sid'], str)
         for f in resp['files']:
             assert f['sha256'] == sha256
-            assert f['name'] == sha256
+            assert f['name'] == os.path.basename(temp_path)
 
         msg = SubmissionTask(scheduler=scheduler, datastore=datastore, **sq.pop(blocking=False))
         assert msg.submission.sid == resp['sid']


### PR DESCRIPTION
This makes it possible (although still discouraged) to submit files within the JSON data block of the submission (low volume), but not ingestion (high volume) API.

We would like to see this supported to avoid the need of implementing an API gateway between AssemblyLine and our ticket system / SOAR. Unfortunately, depending on the use case it only supports sending out raw binary files (plaintext e-mails) or base64-encoded files (attachments) to arbitrary webservice APIs.

Would you consider supporting this use case and merging this PR? Thanks in advance!