### PR TITLE
Only send traceback error messages when debug flag is set

### DIFF
--- a/assemblyline_ui/api/base.py
+++ b/assemblyline_ui/api/base.py
@@ -266,9 +266,12 @@ def make_api_response(data, err="", status_code=200, cookies=None) -> Response:
 
     if type(err) is Exception:
         trace = exc_info()[2]
-        err = ''.join(['\n'] + format_tb(trace) +
-                      ['%s: %s\n' % (err.__class__.__name__, str(err))]).rstrip('\n')
         log_with_traceback(LOGGER, trace, "Exception", is_exception=True)
+        if config.ui.debug:
+            err = ''.join(['\n'] + format_tb(trace) +
+                          ['%s: %s\n' % (err.__class__.__name__, str(err))]).rstrip('\n')
+        else:
+            err = "Internal Server Error"
 
     resp = make_response(jsonify({"api_response": data,
                                   "api_error_message": err,

--- a/assemblyline_ui/error.py
+++ b/assemblyline_ui/error.py
@@ -116,5 +116,8 @@ def handle_500(e):
     trace = exc_info()[2]
     log_with_traceback(LOGGER, trace, "Exception", is_exception=True)
 
-    message = ''.join(['\n'] + format_tb(exc_info()[2]) + ['%s: %s\n' % (oe.__class__.__name__, str(oe))]).rstrip('\n')
+    if config.ui.debug:
+        message = ''.join(['\n'] + format_tb(exc_info()[2]) + ['%s: %s\n' % (oe.__class__.__name__, str(oe))]).rstrip('\n')
+    else:
+        message = "Internal Server Error"
     return make_api_response("", message, 500)


### PR DESCRIPTION
Creating a request to comply with OWASP guidance:

> Improper handling of errors can introduce a variety of security problems for a web site. The most common problem is when detailed internal error messages such as stack traces, database dumps, and error codes are displayed to the user (hacker).

This was spoken to here in Discord: https://discord.com/channels/908084610158714900/909824247273246750/1260232770697826438
(though I am not ranger_the_good for clarification).

On the subject of test cases, I was able to create one that would check the error message after generating an exception, however this was caused by user input and should probably be handled, which would break the test later. As for unit testing, I had to patch enough that it didn't seem like a net add for code coverage, so I haven't included either of those here. Happy to talk about how you would prefer to go about this here.