### PR TITLE
Feature/SignatureStatus (master)

### DIFF
--- a/assemblyline_ui/api/v4/signature.py
+++ b/assemblyline_ui/api/v4/signature.py
@@ -271,6 +271,13 @@ def clear_status(signature_id, **kwargs):
         except VersionConflictException as vce:
             LOGGER.info(f"Retrying saving signature due to version conflict: {str(vce)}")
 
+    signature_event_sender.send(signature_obj['type'], {
+        'signature_id': signature_id,
+        'signature_type': signature_obj['type'],
+        'source': signature_obj['source'],
+        'operation': Operation.Modified
+    })
+
     return make_api_response({"success": response})
 
 


### PR DESCRIPTION
Added the clear_status() method in the signature API to reset the control of the status over to the signature's source