### PR TITLE
fix issue with ui_params key_error for no description

### DIFF
--- a/assemblyline_ui/api/v4/ui.py
+++ b/assemblyline_ui/api/v4/ui.py
@@ -253,7 +253,7 @@ def start_ui_submission(ui_sid, **kwargs):
                         return make_api_response({"started": True, "sid": submission['sid']})
 
             allow_description_overwrite = False
-            if not ui_params['description']:
+            if not ui_params.get("description", None):
                 allow_description_overwrite = True
                 ui_params['description'] = f"Inspection of file: {fname}"
 


### PR DESCRIPTION
fix issue with `ui_params` getting `key_error` for no description.
