### PR TITLE
Remove request_id requirement and use message_id for saml_token_id

### DIFF
--- a/assemblyline_ui/api/v4/authentication.py
+++ b/assemblyline_ui/api/v4/authentication.py
@@ -4,7 +4,7 @@ import json
 import os
 import re
 from io import BytesIO
-from typing import Any, Dict
+from typing import Any, Dict, Union
 from urllib.parse import urlparse
 
 import jwt
@@ -461,13 +461,8 @@ def saml_acs(**_):
         return make_api_response({"err_code": 0}, err="SAML disabled on the server", status_code=401)
     request_data: Dict[str, Any] = _prepare_flask_request(request)
     auth: OneLogin_Saml2_Auth = _make_saml_auth(request_data)
-    request_id: str = flsk_session.pop("AuthNRequestID", None)
-
-    if not request_id:
-        # Could not found the request ID, this token was already used, redirect to the UI with the error
-        msg = "Invalid SAML token"
-        data = base64.b64encode(json.dumps({'error': msg}).encode('utf-8')).decode()
-        return redirect(f"https://{config.ui.fqdn}/saml/?data={data}")
+    request_id: Union[str, None] = flsk_session.pop("AuthNRequestID", None)
+    message_id: str = auth.get_last_message_id()
 
     auth.process_response(request_id=request_id)
     errors: list = auth.get_errors()
@@ -532,7 +527,7 @@ def saml_acs(**_):
             return redirect(f"https://{config.ui.fqdn}/saml/?data={data}")
 
         # Generating the Token the UI will use to login
-        saml_token_id = hashlib.sha256(request_id.encode("utf-8", errors='replace')).hexdigest()
+        saml_token_id = hashlib.sha256(message_id.encode("utf-8", errors='replace')).hexdigest()
 
         if get_token_store(username, 'saml').exist(saml_token_id):
             # Token already exists, this may be a replay attack, redirect to the UI with the error


### PR DESCRIPTION
This PR removes the requirement for a `AuthNRequestID` session variable for ACS to succeed. This is not required by the upstream `python3-saml` documentation. Further, it means that any authentication which does not start at `/saml/sso/` fails, such as IdP-initiated authentication flows.

As a result of `request_id` not being required, a different identifier is needed for generating `saml_token_id`. In this context, the appropriate choice is `auth.get_last_message_id()`. This is the ID of the SAMLResponse message that is being processed by the ACS endpoint.

To be very clear:
1. The lack of request ID does not indicate a reused token as the comment suggests. It only indicates that authentication might not have originated at the `/saml/sso/` endpoint, which is valid according to SAML.
2. Protection against replay attacks is still in place by using `auth.get_last_message_id()` for the `saml_token_id` source, because if the same `SAMLResponse` is replayed in the future, then the message ID will be reused, and the check for an existing `saml_token_id` will fail as intended.

This should fix CybercentreCanada/assemblyline#365 although I'm not sure how to go about testing it. As mentioned in the referenced issue, I have tested an effectively equivalent change via a patched container image, but not this specific branch.