### PR TITLE
Hotfix/Submit (dev)

### DIFF
--- a/assemblyline_ui/api/v4/submit.py
+++ b/assemblyline_ui/api/v4/submit.py
@@ -444,7 +444,7 @@ def submit(**kwargs):
             data["params"] = ui_to_submission_params(ui_params)
 
         # Update default external sources based on user request
-        default_external_sources = data.pop('default_external_sources', []) or default_external_sources
+        default_external_sources = ui_params.pop('default_external_sources', []) or default_external_sources
 
         # Update submission parameters as specified by the user
         try:


### PR DESCRIPTION
Getting the `default_external_sources` from the `ui_params` instead of the `data`

