### PR TITLE
Fixed misspelled "contains"

### DIFF
--- a/assemblyline_ui/api/v4/ingest.py
+++ b/assemblyline_ui/api/v4/ingest.py
@@ -131,7 +131,7 @@ def ingest_single_file(**kwargs):
 
             The multipart/form-data for sending binary has two parts:
                 - The first part contains a JSON dump of the optional params and uses the name 'json'
-                - The last part conatins the file binary, uses the name 'bin' and includes a filename
+                - The last part contains the file binary, uses the name 'bin' and includes a filename
 
             If your system can handle the memory footprint and slowdown, you can also submit a file
             via the plaintext (not encoded) or base64 (encoded) parameters included in the data block.

--- a/assemblyline_ui/api/v4/submit.py
+++ b/assemblyline_ui/api/v4/submit.py
@@ -332,7 +332,7 @@ def submit(**kwargs):
 
             The multipart/form-data for sending binary has two parts:
                 - The first part contains a JSON dump of the optional params and uses the name 'json'
-                - The last part conatins the file binary, uses the name 'bin' and includes a filename
+                - The last part contains the file binary, uses the name 'bin' and includes a filename
 
             If your system can handle the memory footprint and slowdown, you can also submit a file
             via the plaintext (not encoded) or base64 (encoded) parameters included in the data block.


### PR DESCRIPTION
In the API docs there was a typo of the word "contains" which was written as "conatins"