### PR TITLE
Modify init submission to use the original specified filename

### DIFF
--- a/assemblyline_ui/helper/submission.py
+++ b/assemblyline_ui/helper/submission.py
@@ -66,7 +66,6 @@ except socket.gaierror:
     MYIP = '127.0.0.1'
 
 
-
 #############################
 # download functions
 class FileTooBigException(Exception):
@@ -145,7 +144,7 @@ def init_submission(request: Request, user: Dict, endpoint: str):
             data = {}
 
         binary = request.files['bin']
-        name = safe_str(os.path.basename(data.get("name", binary.filename) or ""))
+        name = safe_str(data.get("name", os.path.basename(binary.filename or "")))
     elif 'application/json' in request.content_type:
         data = request.json
         binary = data.get('plaintext', '').encode() or base64.b64decode(data.get('base64', ''))

--- a/test/test_submit.py
+++ b/test/test_submit.py
@@ -22,7 +22,6 @@ from assemblyline.odm.random_data import (
     wipe_submissions,
     wipe_users,
 )
-
 from assemblyline.odm.randomizer import get_random_phrase, random_minimal_obj
 from assemblyline.remote.datatypes.queues.named import NamedQueue
 
@@ -238,8 +237,11 @@ def test_submit_binary_different_filename(datastore, login_session, scheduler, f
 
         with open(temp_path, "rb") as fh:
             sha256 = hashlib.sha256(byte_str).hexdigest()
-            json_data = {"name": filename, "metadata": {"test": "test_submit_binary"}}
+            json_data = {"metadata": {"test": "test_submit_binary"}}
+            if filename:
+                json_data["name"] = filename
             data = {"json": json.dumps(json_data)}
+
             resp = get_api_data(
                 session, f"{host}/api/v4/submit/", method="POST", data=data, files={"bin": fh}, headers={}
             )
@@ -252,9 +254,6 @@ def test_submit_binary_different_filename(datastore, login_session, scheduler, f
                 assert f["name"] == json_data["name"]
             else:
                 assert f["name"] == os.path.basename(temp_path)
-
-        msg = SubmissionTask(scheduler=scheduler, datastore=datastore, **sq.pop(blocking=False))
-        assert msg.submission.sid == resp["sid"]
 
     finally:
         # noinspection PyBroadException


### PR DESCRIPTION
To fix this issue: https://cccs.atlassian.net/browse/AL-3866

When submitting a file using 
`client.ingest(sha256=[SHA256], params={'ignore_cache':True}, fname="./[FILENAME]")`
The resulting filename in AL does not start with `./` , as it gets stripped.

