### PR TITLE
Fix setting default selected based on known profile

### DIFF
--- a/assemblyline_ui/helper/service.py
+++ b/assemblyline_ui/helper/service.py
@@ -51,7 +51,7 @@ def get_default_submission_profiles(user_default_values={}, classification=CLASS
             out[profile.name] = recursive_update(profile_values, user_default_values.get(profile.name, {}))
             if not out[profile.name]["services"].get("selected"):
                 # Provide the default service selection
-                out[profile.name]["services"]["selected"] = DEFAULT_SRV_SEL
+                out[profile.name]["services"]["selected"] = profile.params.services.selected
 
     return out
 


### PR DESCRIPTION
This would fix cases where a user has set `selected: []` or if the API is supplementing a configuration for a profile that doesn't appear in the user settings.