### PR TITLE
feat: add full tree inspection parameters to the API.

### DIFF
--- a/assemblyline_ui/api/v4/submission.py
+++ b/assemblyline_ui/api/v4/submission.py
@@ -229,7 +229,6 @@ def get_file_submission_results(sid, sha256, **kwargs):
     else:
         return make_api_response("", "You are not allowed to view the data of this submission", 403)
 
-
 @submission_api.route("/tree/<sid>/", methods=["GET"])
 @api_login(require_role=[ROLES.submission_view])
 def get_file_tree(sid, **kwargs):
@@ -241,8 +240,8 @@ def get_file_tree(sid, **kwargs):
     Variables:
     sid         => Submission ID to get the tree for
 
-    Arguments:
-    None
+    Arguments (optional):
+    get_full_tree => Boolean value requesting to guarantee to get a full tree with no truncation (default is false).
 
     Data Block:
     None
@@ -260,6 +259,7 @@ def get_file_tree(sid, **kwargs):
 
     """
     user = kwargs['user']
+    get_full_tree = request.args.get('get_full_tree', 'false').lower() in ['true', '']
 
     data = STORAGE.submission.get(sid, as_obj=False)
     if data is None:
@@ -268,7 +268,8 @@ def get_file_tree(sid, **kwargs):
     if data and user and Classification.is_accessible(user['classification'], data['classification']):
         return make_api_response(STORAGE.get_or_create_file_tree(data, config.submission.max_extraction_depth,
                                                                  cl_engine=Classification,
-                                                                 user_classification=user['classification']))
+                                                                 user_classification=user['classification'],
+                                                                 get_full_tree=get_full_tree))
     else:
         return make_api_response("", "You are not allowed to view the data of this submission", 403)
 
@@ -285,8 +286,8 @@ def get_full_results(sid, **kwargs):
     Variables:
     sid         => Submission ID to get the full results for
 
-    Arguments:
-    None
+    Arguments (optional):
+    get_full_tree => Boolean value requesting to guarantee to get a full tree with no truncation (default is false).
 
     Data Block:
     None
@@ -416,10 +417,12 @@ def get_full_results(sid, **kwargs):
     if data and user and Classification.is_accessible(user['classification'], data['classification']):
         res_keys = data.get("results", [])
         err_keys = data.get("errors", [])
+        get_full_tree = request.args.get('get_full_tree', 'false').lower() in ['true', '']
 
         data['file_tree'] = STORAGE.get_or_create_file_tree(data, config.submission.max_extraction_depth,
                                                             cl_engine=Classification,
-                                                            user_classification=user['classification'])['tree']
+                                                            user_classification=user['classification'],
+                                                            get_full_tree=get_full_tree)['tree']
         data['file_infos'], data['missing_file_keys'] = get_file_infos(recursive_flatten_tree(data['file_tree']))
         data.update(get_results(res_keys))
         data.update(get_errors(err_keys))
@@ -915,8 +918,8 @@ def get_report(submission_id, **kwargs):
     Variables:
     submission_id   ->   ID of the submission to create the report for
 
-    Arguments:
-    None
+    Arguments (optional):
+    get_full_tree => Boolean value requesting to guarantee to get a full tree with no truncation (default is false).
 
     Data Block:
     None
@@ -931,6 +934,8 @@ def get_report(submission_id, **kwargs):
 
     submission['important_files'] = set()
     submission['report_filtered'] = False
+    
+    get_full_tree = request.args.get('get_full_tree', 'false').lower() in ['true', '']
 
     if user and Classification.is_accessible(user['classification'], submission['classification']):
         if submission['state'] != 'completed':
@@ -938,7 +943,8 @@ def get_report(submission_id, **kwargs):
                                          f"Submission ID {submission_id} is incomplete.", 425)
 
         tree = STORAGE.get_or_create_file_tree(submission, config.submission.max_extraction_depth,
-                                               cl_engine=Classification, user_classification=user['classification'])
+                                               cl_engine=Classification, user_classification=user['classification'], 
+                                               get_full_tree=get_full_tree)
         submission['file_tree'] = tree['tree']
         submission['classification'] = Classification.max_classification(submission['classification'],
                                                                          tree['classification'])

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - "3000:3000"
 
   al_ui:
-    image: cccs/assemblyline_dev:4.6.1
+    image: cccs/assemblyline_dev:4.7.1
     ports:
       - "5000:5000"
     volumes:
@@ -24,7 +24,7 @@ services:
         condition: service_started
 
   al_socketio:
-    image: cccs/assemblyline_dev:4.6.1
+    image: cccs/assemblyline_dev:4.7.1
     ports:
       - "5002:5002"
     volumes:
@@ -95,7 +95,7 @@ services:
 
 
   openldap:
-    image: docker.io/bitnami/openldap:2.6
+    image: docker.io/bitnamilegacy/openldap:2.6
     ports:
       - '389:389'
     environment:

--- a/test/test_submission.py
+++ b/test/test_submission.py
@@ -90,6 +90,20 @@ def test_get_submission_full(datastore, login_session):
 
 
 # noinspection PyUnusedLocal
+def test_get_submission_full(datastore, login_session):
+    _, session, host = login_session
+
+    submission = random.choice(datastore.submission.search("id:*", rows=NUM_SUBMISSIONS, as_obj=False)['items'])
+    resp = get_api_data(session, f"{host}/api/v4/submission/full/{submission['sid']}/", params={"get_full_tree": "true"})
+    assert resp['sid'] == submission['sid']
+    assert resp['params']['description'] == submission['params']['description']
+    assert isinstance(resp['file_tree'], dict)
+    
+    # Verify that the submission has truncated false for all entries to verify this is the full tree.
+    for k, v in resp['file_tree'].items():
+        assert v.get("truncated", True) is False
+
+# noinspection PyUnusedLocal
 def test_get_submission_report(datastore, login_session):
     _, session, host = login_session
 
@@ -104,6 +118,20 @@ def test_get_submission_report(datastore, login_session):
     assert isinstance(resp['heuristics'], dict)
     assert isinstance(resp['tags'], dict)
     assert isinstance(resp['promoted_sections'], list)
+    
+# noinspection PyUnusedLocal
+def test_get_submission_report(datastore, login_session):
+    _, session, host = login_session
+
+    submission = random.choice(datastore.submission.search("id:*", rows=NUM_SUBMISSIONS, as_obj=False)['items'])
+    resp = get_api_data(session, f"{host}/api/v4/submission/report/{submission['sid']}/", params={"get_full_tree": "true"})
+    assert resp['sid'] == submission['sid']
+    assert resp['params']['description'] == submission['params']['description']
+    assert isinstance(resp['file_tree'], dict)
+    
+        # Verify that the submission has truncated false for all entries to verify this is the full tree.
+    for k, v in resp['file_tree'].items():
+        assert v.get("truncated", True) is False
 
 
 # noinspection PyUnusedLocal
@@ -129,6 +157,25 @@ def test_get_submission_tree(datastore, login_session):
 
     for k in resp['tree']:
         assert len(k) == 64
+        
+# noinspection PyUnusedLocal
+def test_get_submission_tree_get_full_tree(datastore, login_session):
+    # READY to test now that I found params.
+    _, session, host = login_session
+
+    submission = random.choice(datastore.submission.search("id:*", rows=NUM_SUBMISSIONS, as_obj=False)['items'])
+    resp = get_api_data(session, f"{host}/api/v4/submission/tree/{submission['sid']}/", params={"get_full_tree": "true"})
+    assert isinstance(resp, dict)
+    assert "classification" in resp
+    assert "filtered" in resp
+    assert "tree" in resp
+
+    for k in resp['tree']:
+        assert len(k) == 64
+    
+    # Verify that the submission has truncated false for all entries to verify this is the full tree.
+    for k, v in resp['tree'].items():
+        assert v.get("truncated", True) is False
 
 
 # noinspection PyUnusedLocal

--- a/test/test_submission.py
+++ b/test/test_submission.py
@@ -90,7 +90,7 @@ def test_get_submission_full(datastore, login_session):
 
 
 # noinspection PyUnusedLocal
-def test_get_submission_full(datastore, login_session):
+def test_get_submission_full_get_full_tree(datastore, login_session):
     _, session, host = login_session
 
     submission = random.choice(datastore.submission.search("id:*", rows=NUM_SUBMISSIONS, as_obj=False)['items'])
@@ -120,7 +120,7 @@ def test_get_submission_report(datastore, login_session):
     assert isinstance(resp['promoted_sections'], list)
     
 # noinspection PyUnusedLocal
-def test_get_submission_report(datastore, login_session):
+def test_get_submission_report_get_full_tree(datastore, login_session):
     _, session, host = login_session
 
     submission = random.choice(datastore.submission.search("id:*", rows=NUM_SUBMISSIONS, as_obj=False)['items'])


### PR DESCRIPTION
feat: add full tree inspection parameters to the API.

Allows users to request the full file tree without any truncation.
This means files may be duplicated but you are guaranteed to get all the different paths for all the different services.
There is a corresponding change in the assemblyline-base to provide the backend functionality for these parameters to be useful.

This PR also fixes the docker-compose.yaml file for testing which wasn't working.