### PR TITLE
update the base documentation for apikeys endpoint

### DIFF
--- a/assemblyline_ui/api/v4/apikey.py
+++ b/assemblyline_ui/api/v4/apikey.py
@@ -27,9 +27,9 @@ SCOPES = {
 }
 
 
-
 SUB_API = 'apikey'
 apikey_api = make_subapi_blueprint(SUB_API, api_version=4)
+apikey_api._doc = "View and manage Apikeys"
 
 
 @apikey_api.route("/list/", methods=["GET"])


### PR DESCRIPTION
Update the documentation for the `apikey` endpoint.

<img width="1590" height="49" alt="image" src="https://github.com/user-attachments/assets/a7342255-4a4b-4c68-9fdc-a241ad3f3953" />
