### PR TITLE
File Viewer: render UTF-8 instead of dot-replacing non-ASCII bytes

### DIFF
--- a/assemblyline_ui/api/v4/file.py
+++ b/assemblyline_ui/api/v4/file.py
@@ -7,7 +7,7 @@ import tempfile
 from assemblyline.common.codec import encode_file
 from assemblyline.common.dict_utils import unflatten
 from assemblyline.common.hexdump import dump, hexdump
-from assemblyline.common.str_utils import safe_str
+from assemblyline.common.str_utils import dotdump_utf8, safe_str
 from assemblyline.common.threading import APMAwareThreadPoolExecutor
 from assemblyline.datastore.collection import Index
 from assemblyline.filestore import FileStoreException
@@ -38,8 +38,6 @@ from assemblyline_ui.helper.user import load_user_settings
 
 LABEL_CATEGORIES = ['attribution', 'technique', 'info']
 MAX_CONCURRENT_VECTORS = 5
-
-FILTER_ASCII = b''.join([bytes([x]) if x in range(32, 127) or x in [9, 10, 13] else b'.' for x in range(256)])
 
 SUB_API = 'file'
 file_api = make_subapi_blueprint(SUB_API, api_version=4)
@@ -73,7 +71,10 @@ def retrieve_file_content(file_obj: dict) -> bytes:
 @api_login(require_role=[ROLES.file_detail])
 def get_file_ascii(sha256, **kwargs):
     """
-    Return the ascii values for a file where ascii chars are replaced by DOTs.
+    Return a UTF-8 rendering of the file where bytes that are not part of a
+    valid printable UTF-8 sequence (or tab/LF/CR) are replaced by DOTs. Valid
+    UTF-8 multi-byte characters (e.g. accented letters, CJK characters, emoji)
+    are preserved instead of being shown as dots.
 
     Variables:
     sha256       => A resource locator for the file (sha256)
@@ -86,7 +87,7 @@ def get_file_ascii(sha256, **kwargs):
 
     Result example:
     {
-      "content": <THE ASCII FILE>,
+      "content": <THE UTF-8 RENDERED FILE>,
       "truncated": false
     }
     """
@@ -111,7 +112,7 @@ def get_file_ascii(sha256, **kwargs):
             data = data[:API_MAX_SIZE]
 
         return make_api_response({
-            "content": data.translate(FILTER_ASCII).decode(),
+            "content": dotdump_utf8(data),
             "truncated": file_obj['size'] > API_MAX_SIZE
         })
     else:


### PR DESCRIPTION
## Summary

Make the File Viewer's ASCII tab render **UTF-8** text instead of replacing
every non-ASCII byte with `.`. Files containing accented Latin
(`café`), CJK (`日本語`), emoji (`🎉`), etc. now display as actual
characters in the viewer.

## Why

`GET /api/v4/file/ascii/<sha256>/` ran
`data.translate(FILTER_ASCII).decode()`. `FILTER_ASCII` is a 256-byte
table that maps every byte outside printable ASCII (32–126, plus
tab/LF/CR) to `.`. Because every byte of a UTF-8 multi-byte sequence
sits in the `0x80–0xFF` range, the table dot-replaced every byte of
every non-ASCII character, so any file containing UTF-8 text rendered
as walls of dots.

## Change

- Swap the byte-translation table for the new
  `assemblyline.common.str_utils.dotdump_utf8()` helper.
- Helper preserves valid UTF-8 multi-byte sequences (per the existing
  RFC 3629 `_valid_utf8` regex) and replaces only invalid or
  non-printable bytes with `.`.
- Update the docstring & `Result example` wording.
- Drop the now-unused `FILTER_ASCII` constant.
- Response envelope `{"content": ..., "truncated": ...}` and the
  `API_MAX_SIZE` truncation behaviour are unchanged.

## Behaviour matrix

| Input | Old `content` | New `content` |
|---|---|---|
| `b'hello\nworld'` | `'hello\nworld'` | `'hello\nworld'` |
| `'café'.encode()` | `'caf..'` | `'café'` |
| `'日本語'.encode()` | `'.........'` | `'日本語'` |
| `'🎉ok'.encode()` | `'....ok'` | `'🎉ok'` |
| `b'A\x00B\x07C'` | `'A.B.C'` | `'A.B.C'` |
| `b'\xc3('` (bad UTF-8) | `'.('` | `'.('` |
| `b'\xed\xa0\x80'` (UTF-16 surrogate) | `'...'` | `'...'` |

Pure-ASCII output is byte-identical to the old behaviour. Invalid /
control bytes still produce `.`.

## Dependency

This PR depends on
[CybercentreCanada/assemblyline-base#2146](https://github.com/CybercentreCanada/assemblyline-base/pull/2146),
which adds the `dotdump_utf8` helper to
`assemblyline.common.str_utils`. Please merge that first (or release a
version of `assemblyline-base` that contains it) before merging this PR.

## Risk

- Single endpoint changed; response shape unchanged.
- Frontend already renders the `content` string in a `<pre>` block as
  UTF-8 — no frontend change required.
- Existing `test_ascii` in `assemblyline-ui/test/test_file.py` asserts
  on a sha256 hex string (pure ASCII) and continues to pass.
