### PR TITLE
feat: add MCP-based agentic AI framework

### DIFF
--- a/assemblyline_ui/api/v4/assistant.py
+++ b/assemblyline_ui/api/v4/assistant.py
@@ -1,8 +1,11 @@
+import asyncio
+
 from assemblyline.odm.models.user import ROLES
 from flask import request
 
 from assemblyline_ui.api.base import api_login, make_api_response, make_subapi_blueprint
 from assemblyline_ui.config import AI_AGENT, AUDIT_LOG
+from assemblyline_ui.helper.ai.base import APIException, EmptyAIResponse
 
 SUB_API = 'assistant'
 
@@ -84,3 +87,126 @@ def assistant_conversation(**kwargs):
             break
 
     return make_api_response(AI_AGENT.continued_ai_conversation(messages, lang=lang))
+
+
+def _run_async(coro):
+    """Run an async coroutine from sync Flask context."""
+    try:
+        loop = asyncio.get_event_loop()
+        if loop.is_running():
+            import concurrent.futures
+            with concurrent.futures.ThreadPoolExecutor() as pool:
+                return pool.submit(asyncio.run, coro).result()
+        return loop.run_until_complete(coro)
+    except RuntimeError:
+        return asyncio.run(coro)
+
+
+@assistant_api.route("/agents/", methods=["GET"])
+@api_login(require_role=[ROLES.assistant_use])
+def list_agent_profiles(**kwargs):
+    """
+    List available AI agent profiles and their capabilities.
+
+    Variables:
+    None
+
+    Arguments:
+    None
+
+    Data Block:
+    None
+
+    API call example:
+    /api/v4/assistant/agents/
+
+    Result example:
+    [
+      {
+        "name": "analyst",
+        "description": "General-purpose malware analyst assistant"
+      }
+    ]
+    """
+    if not AI_AGENT.has_agent_profiles():
+        return make_api_response([], "No agent profiles configured", 200)
+
+    return make_api_response(AI_AGENT.get_agent_profile_list())
+
+
+@assistant_api.route("/agents/<agent_name>/", methods=["POST"])
+@api_login(require_role=[ROLES.assistant_use])
+def agentic_conversation(agent_name, **kwargs):
+    """
+    Run an agentic conversation with tool calling using a named agent profile.
+
+    The agent calls tools from registered MCP servers to answer the user's
+    question. MCP servers and agent profiles are configured by the deployer
+    via values.yaml.
+
+    Variables:
+    agent_name     => Name of the agent profile to use
+
+    Arguments:
+    lang           => Which language do you want the AI to respond in?
+
+    Data Block:
+    [
+      {
+        "role": "user",
+        "content": "What services flagged this file?"
+      }
+    ]
+
+    API call example:
+    /api/v4/assistant/agents/analyst/
+
+    Result example:
+    {
+      "trace": [...],
+      "truncated": false
+    }
+    """
+    user = kwargs['user']
+    lang = request.args.get('lang', 'english')
+    messages = request.json
+
+    if not isinstance(messages, list):
+        return make_api_response({}, "Input messages are not in the right format", 400)
+    if not messages:
+        return make_api_response({}, "No conversation messages provided", 400)
+
+    if not AI_AGENT.has_agent_profiles():
+        return make_api_response({}, "No agent profiles configured on this system", 400)
+
+    profile = AI_AGENT.agent_profiles.get(agent_name)
+    if not profile:
+        return make_api_response({}, f"Unknown agent profile: {agent_name}", 404)
+
+    if profile.require_role and profile.require_role not in user.get('roles', []):
+        AUDIT_LOG.warning(
+            f"{user['uname']} [{user['classification']}] :: "
+            f"agentic_conversation DENIED: agent={agent_name}, missing role={profile.require_role}")
+        return make_api_response({}, f"Missing required role: {profile.require_role}", 403)
+
+    for message in messages:
+        if 'role' not in message:
+            return make_api_response({}, "Input messages are not in the right format", 400)
+
+    # Audit
+    for message in messages[::-1]:
+        if message['role'] == "user":
+            AUDIT_LOG.info(
+                f"{user['uname']} [{user['classification']}] :: "
+                f"agentic_conversation(agent={agent_name}, content={message.get('content', '')})")
+            break
+
+    try:
+        result = _run_async(AI_AGENT.agentic_conversation(agent_name, messages, user=user, lang=lang))
+        return make_api_response(result)
+    except APIException as e:
+        AUDIT_LOG.error(f"{user['uname']} :: agentic_conversation error: agent={agent_name}, {e}")
+        return make_api_response({}, str(e), 400)
+    except EmptyAIResponse as e:
+        AUDIT_LOG.warning(f"{user['uname']} :: agentic_conversation empty: agent={agent_name}, {e}")
+        return make_api_response({}, str(e), 404)

--- a/assemblyline_ui/api/v4/user.py
+++ b/assemblyline_ui/api/v4/user.py
@@ -290,7 +290,8 @@ def who_am_i(**kwargs):
         },
         "ui": {
             "ai": {
-                "enabled": AI_AGENT.has_backends()
+                "enabled": AI_AGENT.has_backends(),
+                "agent_profiles": AI_AGENT.get_agent_profile_list() if AI_AGENT.has_agent_profiles() else []
             },
             "alerting_meta": {
                 "important": config.ui.alerting_meta.important,

--- a/assemblyline_ui/helper/ai/base.py
+++ b/assemblyline_ui/helper/ai/base.py
@@ -1,7 +1,7 @@
 from typing import List
 from assemblyline.common import forge
 from assemblyline.common.log import PrintLogger
-from assemblyline.odm.models.config import AIFunctionParameters, Config, AIConnection
+from assemblyline.odm.models.config import AIAgentProfile, AIFunctionParameters, Config, AIConnection
 from assemblyline.odm.models.service import Service
 
 
@@ -45,6 +45,9 @@ class AIAgent():
     def summarize_code_snippet(self, code, lang="english", with_trace=False):
         raise UnimplementedException("Method not implemented yet")
 
+    def agentic_conversation(self, messages, tools_openai, mcp_registry, agent_profile, user=None, lang="english"):
+        raise UnimplementedException("Agentic conversations not supported by this backend")
+
     def set_system_prompts(self, system_prompt, scoring_prompt, classification_prompt,
                            services_prompt, indices_prompt, definition_prompt):
         self.system_prompt = system_prompt
@@ -83,6 +86,18 @@ class AIAgentPool():
 
         # Load backends
         self.api_backends: List[AIAgent] = api_backends
+
+        # Load MCP tool registry and agent profiles from config
+        self.mcp_registry = None
+        self.agent_profiles: dict[str, AIAgentProfile] = {}
+        self._mcp_initialized = False
+
+        if config.ui.ai_backends.mcp_servers:
+            from assemblyline_ui.helper.ai.mcp_client import MCPToolRegistry
+            self.mcp_registry = MCPToolRegistry(config.ui.ai_backends.mcp_servers)
+
+        for profile in config.ui.ai_backends.agent_profiles:
+            self.agent_profiles[profile.name] = profile
 
     def has_backends(self):
         return len(self.api_backends) != 0
@@ -142,6 +157,92 @@ class AIAgentPool():
             raise last_error
 
         raise EmptyAIResponse("Could not find any AI backend to answer the question")
+
+    def has_agent_profiles(self):
+        return len(self.agent_profiles) != 0
+
+    def get_agent_profile_list(self):
+        """Return list of available agent profiles (name + description, for UI display)."""
+        return [{'name': p.name, 'description': p.description} for p in self.agent_profiles.values()]
+
+    async def ensure_mcp_initialized(self):
+        """Initialize MCP connections if not already done. Called lazily on first agentic request."""
+        if self.mcp_registry and not self._mcp_initialized:
+            self.logger.info("Initializing MCP connections (first agentic request)")
+            self.mcp_registry.initialize()
+            self._mcp_initialized = True
+            self.logger.info(f"MCP initialized: {len(self.mcp_registry.get_all_tool_names())} tools available")
+
+    async def agentic_conversation(self, agent_name, messages, user=None, lang="english"):
+        """Run an agentic conversation with MCP tool calling using a named agent profile."""
+        username = user.get('uname', 'unknown') if user else 'unknown'
+        self.logger.info(f"Agentic conversation started: agent='{agent_name}', user='{username}'")
+
+        profile = self.agent_profiles.get(agent_name)
+        if not profile:
+            self.logger.warning(f"Unknown agent profile requested: '{agent_name}'")
+            raise APIException(f"Unknown agent profile: {agent_name}")
+
+        if not self.mcp_registry:
+            self.logger.error("Agentic conversation requested but no MCP servers configured")
+            raise APIException("No MCP servers configured for agentic workflows")
+
+        # Ensure MCP connections are up
+        await self.ensure_mcp_initialized()
+
+        # Resolve which tools this agent can see
+        tool_names = self.mcp_registry.filter_tools(
+            server_names=profile.mcp_servers,
+            include=profile.tools if profile.tools else None,
+            exclude=profile.excluded_tools if profile.excluded_tools else None,
+        )
+
+        if not tool_names:
+            self.logger.error(f"No tools available for agent '{agent_name}' after filtering "
+                             f"(servers={profile.mcp_servers}, include={profile.tools}, "
+                             f"exclude={profile.excluded_tools})")
+            raise APIException(f"No tools available for agent '{agent_name}'. "
+                               f"Check MCP server connectivity and profile configuration.")
+
+        self.logger.info(f"Agent '{agent_name}': {len(tool_names)} tools available: {tool_names}")
+
+        # Convert to OpenAI format
+        tools_openai = self.mcp_registry.to_openai_tools(tool_names)
+
+        # Inject system message
+        system_content = "\n\n".join([
+            profile.system_message,
+            self.system_prompt if hasattr(self, 'system_prompt') else '',
+        ]).strip()
+
+        if messages and messages[0].get('role') == 'system':
+            messages[0]['content'] = system_content
+        else:
+            messages.insert(0, {'role': 'system', 'content': system_content})
+
+        # Try each backend
+        last_error = None
+        for backend in self.api_backends:
+            try:
+                return await backend.agentic_conversation(
+                    messages=messages,
+                    tools_openai=tools_openai,
+                    mcp_registry=self.mcp_registry,
+                    agent_profile=profile,
+                    user=user,
+                    lang=lang,
+                )
+            except (APIException, UnimplementedException) as e:
+                self.logger.debug(f"Backend {type(backend).__name__} failed for agentic conversation: {e}")
+                last_error = e
+                continue
+
+        if last_error:
+            self.logger.error(f"All backends failed for agentic conversation: {last_error}")
+            raise last_error
+
+        self.logger.error("No AI backend available for agentic workflows")
+        raise EmptyAIResponse("No AI backend available for agentic workflows")
 
     def _build_scoring_prompt(self):
         scoring = f"""Assemblyline uses a scoring mechanism where any scores below

--- a/assemblyline_ui/helper/ai/mcp_client.py
+++ b/assemblyline_ui/helper/ai/mcp_client.py
@@ -1,0 +1,266 @@
+"""
+MCP (Model Context Protocol) client for AI agentic workflows.
+
+Connects to registered MCP servers, discovers their tools via the MCP protocol,
+and executes tool calls. MCP servers self-describe their capabilities, so no
+manual tool parameter configuration is needed — just register the server URL.
+
+Uses the official `mcp` Python SDK for protocol handling.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import threading
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from assemblyline.odm.models.config import MCPServerRegistration
+
+logger = logging.getLogger('assemblyline.ui.ai.mcp')
+
+
+class _MCPServerConnection:
+    """Manages a single MCP server connection in a dedicated thread.
+
+    The MCP SDK's sse_client uses anyio task groups that require the async
+    context manager to stay open for the lifetime of the connection. We run
+    each server in its own thread with its own event loop so the async with
+    block stays intact.
+    """
+
+    def __init__(self, name: str, url: str, transport: str, headers: dict, verify: bool = True):
+        self.name = name
+        self.url = url
+        self.transport = transport
+        self.headers = headers
+        self.verify = verify
+        self.tools: Dict[str, dict] = {}
+        self._session = None
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._thread: Optional[threading.Thread] = None
+        self._ready = threading.Event()
+        self._error: Optional[str] = None
+
+    def start(self, timeout: float = 30):
+        """Start the connection in a background thread. Blocks until ready or timeout."""
+        logger.info(f"MCP server '{self.name}': connecting to {self.url}")
+        self._thread = threading.Thread(target=self._run_loop, daemon=True)
+        self._thread.start()
+        if not self._ready.wait(timeout=timeout):
+            logger.error(f"MCP server '{self.name}': connection timed out after {timeout}s")
+            raise TimeoutError(f"MCP server '{self.name}' did not connect within {timeout}s")
+        if self._error:
+            logger.error(f"MCP server '{self.name}': connection failed: {self._error}")
+            raise ConnectionError(self._error)
+
+    def _run_loop(self):
+        """Thread entry: create event loop and run the MCP connection."""
+        self._loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self._loop)
+        try:
+            self._loop.run_until_complete(self._connect())
+        except Exception as e:
+            logger.error(f"MCP server '{self.name}': background thread error: {e}")
+            self._error = str(e)
+            self._ready.set()
+
+    async def _connect(self):
+        """Connect to the MCP server and keep the connection alive."""
+        from mcp import ClientSession
+        from mcp.client.sse import sse_client
+
+        # Build factory that respects the verify setting
+        def httpx_factory(**kwargs):
+            import httpx
+            kwargs.setdefault('verify', self.verify)
+            return httpx.AsyncClient(**kwargs)
+
+        async with sse_client(url=self.url, headers=self.headers,
+                              httpx_client_factory=httpx_factory) as streams:
+            if len(streams) == 3:
+                read_stream, write_stream, _ = streams
+            else:
+                read_stream, write_stream = streams
+
+            async with ClientSession(read_stream, write_stream) as session:
+                await session.initialize()
+                self._session = session
+
+                # Discover tools
+                tools_response = await session.list_tools()
+                for tool in tools_response.tools:
+                    self.tools[f"{self.name}.{tool.name}"] = {
+                        'server': self.name,
+                        'mcp_tool_name': tool.name,
+                        'description': tool.description or '',
+                        'input_schema': tool.inputSchema if hasattr(tool, 'inputSchema') else {},
+                    }
+
+                logger.info(f"MCP server '{self.name}': discovered {len(tools_response.tools)} tools")
+                self._ready.set()
+
+                # Keep connection alive until the thread is stopped
+                try:
+                    while True:
+                        await asyncio.sleep(1)
+                except asyncio.CancelledError:
+                    logger.debug(f"MCP server '{self.name}': connection thread cancelled")
+
+    async def call_tool(self, tool_name: str, arguments: dict) -> Any:
+        """Execute a tool call. Must be called from the server's own event loop."""
+        if not self._session:
+            raise RuntimeError(f"No session for MCP server '{self.name}'")
+        return await self._session.call_tool(tool_name, arguments=arguments)
+
+    def call_tool_sync(self, tool_name: str, arguments: dict, timeout: float = 120) -> Any:
+        """Execute a tool call from any thread, dispatching to the server's event loop."""
+        if not self._loop or not self._session:
+            logger.error(f"MCP server '{self.name}': no active connection for tool call '{tool_name}'")
+            raise RuntimeError(f"No active connection for MCP server '{self.name}'")
+        future = asyncio.run_coroutine_threadsafe(
+            self._session.call_tool(tool_name, arguments=arguments),
+            self._loop
+        )
+        try:
+            return future.result(timeout=timeout)
+        except TimeoutError:
+            logger.error(f"MCP server '{self.name}': tool call '{tool_name}' timed out after {timeout}s")
+            raise
+
+    def stop(self):
+        """Stop the connection."""
+        logger.info(f"MCP server '{self.name}': shutting down")
+        if self._loop:
+            for task in asyncio.all_tasks(self._loop):
+                self._loop.call_soon_threadsafe(task.cancel)
+            self._loop.call_soon_threadsafe(self._loop.stop)
+        if self._thread:
+            self._thread.join(timeout=5)
+
+
+class MCPToolRegistry:
+    """Discovers and executes tools from registered MCP servers.
+
+    Each MCP server runs in a dedicated background thread with its own event
+    loop, keeping the SSE connection alive. Tool calls are dispatched to the
+    correct server's event loop via thread-safe futures.
+    """
+
+    def __init__(self, mcp_servers: List['MCPServerRegistration']):
+        self._servers: Dict[str, Any] = {}  # config objects
+        self._connections: Dict[str, _MCPServerConnection] = {}
+        self._tools: Dict[str, dict] = {}
+
+        for server in mcp_servers:
+            self._servers[server.name] = server
+
+    def initialize(self):
+        """Connect to all MCP servers and discover their tools. Synchronous."""
+        logger.info(f"Initializing MCP connections for {len(self._servers)} server(s)")
+        for name, server in self._servers.items():
+            try:
+                headers = dict(server.headers) if server.headers else {}
+
+                # Inject FIC bearer token if configured
+                if server.use_fic:
+                    scope = server.fic_scope if hasattr(server, 'fic_scope') and server.fic_scope else 'https://cognitiveservices.azure.com/.default'
+                    headers = self._inject_fic_token(name, headers, scope)
+
+                verify = server.verify if hasattr(server, 'verify') else True
+                conn = _MCPServerConnection(name, server.url, server.transport, headers, verify=verify)
+                conn.start(timeout=server.timeout if hasattr(server, 'timeout') else 30)
+                self._connections[name] = conn
+                self._tools.update(conn.tools)
+            except Exception as e:
+                logger.error(f"Failed to connect to MCP server '{name}' at {server.url}: {e}")
+
+    @staticmethod
+    def _inject_fic_token(server_name: str, headers: dict, scope: str) -> dict:
+        """Acquire a token via Federated Identity Credentials and inject into headers."""
+        try:
+            from azure.identity import DefaultAzureCredential
+            credential = DefaultAzureCredential()
+            token = credential.get_token(scope).token
+            headers['Authorization'] = f'Bearer {token}'
+            logger.info(f"MCP server '{server_name}': acquired FIC token (scope={scope})")
+        except ImportError:
+            logger.warning(f"MCP server '{server_name}': azure-identity not installed, cannot use FIC")
+        except Exception as e:
+            logger.error(f"MCP server '{server_name}': FIC token acquisition failed: {e}")
+        return headers
+
+    def get_all_tool_names(self) -> List[str]:
+        return list(self._tools.keys())
+
+    def get_tools_for_servers(self, server_names: List[str]) -> List[str]:
+        return [name for name, info in self._tools.items() if info['server'] in server_names]
+
+    def filter_tools(self, server_names: List[str],
+                     include: List[str] = None, exclude: List[str] = None) -> List[str]:
+        available = self.get_tools_for_servers(server_names)
+        if include:
+            available = [t for t in available if t in include or t.split('.', 1)[-1] in include]
+        if exclude:
+            available = [t for t in available if t not in exclude and t.split('.', 1)[-1] not in exclude]
+        return available
+
+    def to_openai_tools(self, tool_names: List[str]) -> List[Dict]:
+        openai_tools = []
+        for name in tool_names:
+            tool_info = self._tools.get(name)
+            if not tool_info:
+                continue
+            schema = tool_info.get('input_schema', {})
+            openai_tools.append({
+                'type': 'function',
+                'function': {
+                    'name': name,
+                    'description': tool_info['description'],
+                    'parameters': schema if schema else {'type': 'object', 'properties': {}},
+                }
+            })
+        return openai_tools
+
+    def execute_tool(self, tool_name: str, arguments: Dict[str, Any]) -> str:
+        """Execute a tool call. Synchronous — dispatches to the server's event loop."""
+        tool_info = self._tools.get(tool_name)
+        if not tool_info:
+            logger.warning(f"Tool call for unknown tool: {tool_name}")
+            return json.dumps({'error': f'Unknown tool: {tool_name}'})
+
+        server_name = tool_info['server']
+        mcp_tool_name = tool_info['mcp_tool_name']
+
+        conn = self._connections.get(server_name)
+        if not conn:
+            logger.error(f"No active connection for MCP server '{server_name}' (tool: {tool_name})")
+            return json.dumps({'error': f'No active connection for MCP server: {server_name}'})
+
+        try:
+            result = conn.call_tool_sync(mcp_tool_name, arguments)
+
+            texts = []
+            for block in result.content:
+                if hasattr(block, 'text'):
+                    texts.append(block.text)
+                elif hasattr(block, 'data'):
+                    texts.append(f'[binary data: {len(block.data)} bytes]')
+
+            output = '\n'.join(texts) if texts else json.dumps({'result': 'empty'})
+            if len(output) > 64 * 1024:
+                logger.warning(f"Tool '{tool_name}' response truncated from {len(output)} to 64KB")
+                output = output[:64 * 1024] + '\n... [truncated]'
+            return output
+
+        except Exception as e:
+            logger.exception(f"MCP tool execution failed: {tool_name}")
+            return json.dumps({'error': f'Tool execution failed: {type(e).__name__}: {e}'})
+
+    def close(self):
+        """Close all MCP server connections."""
+        logger.info(f"Closing {len(self._connections)} MCP connection(s)")
+        for conn in self._connections.values():
+            conn.stop()
+        self._connections.clear()

--- a/assemblyline_ui/helper/ai/openai.py
+++ b/assemblyline_ui/helper/ai/openai.py
@@ -1,3 +1,4 @@
+import json
 import requests
 import yaml
 from assemblyline.common.str_utils import safe_str
@@ -17,7 +18,8 @@ class OpenAIAgent(AIAgent):
         if config.use_fic and "openai.azure.com" in config.chat_url:
             try:
                 credentials = DefaultAzureCredential()
-                aad_token = credentials.get_token('https://cognitiveservices.azure.com/.default').token
+                scope = config.fic_scope if hasattr(config, 'fic_scope') and config.fic_scope else 'https://cognitiveservices.azure.com/.default'
+                aad_token = credentials.get_token(scope).token
                 self.config.headers['Authorization'] = f"Bearer {aad_token}"
             except Exception as e:
                 logger.error(f"Could not properly initialize OpenAI Agent using Federated Identity token: {e}")
@@ -136,3 +138,92 @@ class OpenAIAgent(AIAgent):
         data.update(self.params.code.options)
 
         return self._call_ai_backend(data, "summarize code snippet", with_trace=with_trace)
+
+    async def agentic_conversation(self, messages, tools_openai, mcp_registry, agent_profile,
+                                   user=None, lang="english"):
+        """Run an agentic conversation loop with MCP tool calling.
+
+        The LLM decides which tools to call; we execute them via MCP and feed
+        results back until the LLM produces a final text response.
+        """
+        max_iterations = agent_profile.max_iterations
+        options = {k: v for k, v in (agent_profile.options or {}).items() if k in ALLOWED_OPTIONS}
+        self.logger.info(f"Agentic loop starting: model={self.config.model_name}, "
+                        f"max_iterations={max_iterations}, tools={len(tools_openai)}")
+
+        for iteration in range(max_iterations):
+            data = {
+                "max_tokens": agent_profile.max_tokens,
+                "messages": messages,
+                "model": self.config.model_name,
+                "stream": False,
+            }
+            if tools_openai:
+                data["tools"] = tools_openai
+                data["tool_choice"] = "auto"
+            data.update(options)
+
+            try:
+                resp = self.session.post(self.config.chat_url, json=data)
+            except Exception as e:
+                self.logger.error(f"Agentic API call failed on iteration {iteration}: {e}")
+                raise APIException(f"Agentic call failed on iteration {iteration}: {e}")
+
+            if not resp.ok:
+                msg_data = resp.json()
+                msg = msg_data.get('error', {}).get('message', None) or msg_data
+                self.logger.error(f"Agentic API call denied on iteration {iteration}: {msg}")
+                raise APIException(f"Agentic call denied on iteration {iteration}: {msg}")
+
+            choices = resp.json().get('choices', [])
+            if not choices:
+                self.logger.error(f"Empty response from AI on iteration {iteration}")
+                raise EmptyAIResponse("No response from AI during agentic loop")
+
+            message = choices[0]['message']
+            finish_reason = choices[0].get('finish_reason', 'stop')
+
+            tool_calls = message.get('tool_calls')
+            if tool_calls and finish_reason == 'tool_calls':
+                # Append assistant message with tool_calls
+                messages.append({
+                    'role': 'assistant',
+                    'content': message.get('content'),
+                    'tool_calls': tool_calls,
+                })
+
+                # Execute each tool via MCP
+                for tool_call in tool_calls:
+                    func = tool_call.get('function', {})
+                    tool_name = func.get('name', '')
+                    try:
+                        tool_args = json.loads(func.get('arguments', '{}'))
+                    except json.JSONDecodeError:
+                        self.logger.warning(f"Failed to parse tool arguments for {tool_name}, using empty args")
+                        tool_args = {}
+
+                    self.logger.info(f"Agentic tool call [{iteration}]: {tool_name}({tool_args})")
+
+                    tool_result = mcp_registry.execute_tool(tool_name, tool_args)
+
+                    messages.append({
+                        'role': 'tool',
+                        'tool_call_id': tool_call.get('id', ''),
+                        'content': tool_result,
+                    })
+
+                continue
+
+            # No tool calls — final response
+            content = message.get('content', '')
+            messages.append({'role': 'assistant', 'content': content})
+            self.logger.info(f"Agentic loop completed after {iteration + 1} iteration(s)")
+            return {'trace': messages, 'truncated': finish_reason == 'length'}
+
+        # Exhausted iterations
+        self.logger.warning(f"Agentic loop exhausted max_iterations={max_iterations}")
+        messages.append({
+            'role': 'assistant',
+            'content': '[Agent reached maximum iteration limit. Returning partial results.]'
+        })
+        return {'trace': messages, 'truncated': True}

--- a/test/.dockerignore
+++ b/test/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.idea
+venv
+env
+pipelines
+docs
+pip-log.txt
+.tox
+.coverage
+.cache
+*.log

--- a/test/Dockerfile.mcp-ci
+++ b/test/Dockerfile.mcp-ci
@@ -1,0 +1,13 @@
+FROM cccs/assemblyline_dev:4.7.1
+
+# Install MCP SDK
+RUN pip install --no-cache-dir mcp uvicorn starlette
+
+# Copy test files and MCP client (context is test/)
+COPY test_mcp_server.py /opt/test_mcp_server.py
+COPY test_mcp_agent.py /opt/test_mcp_agent.py
+COPY mcp_client.py /opt/mcp_client.py
+COPY run_mcp_tests.sh /opt/run_mcp_tests.sh
+RUN chmod +x /opt/run_mcp_tests.sh
+
+CMD ["/opt/run_mcp_tests.sh"]

--- a/test/Dockerfile.mcp-test
+++ b/test/Dockerfile.mcp-test
@@ -1,0 +1,4 @@
+FROM cccs/assemblyline_dev:4.7.1
+
+# Install MCP SDK for the test MCP server and agentic framework
+RUN pip install --no-cache-dir mcp uvicorn starlette

--- a/test/config/config.yml
+++ b/test/config/config.yml
@@ -75,3 +75,28 @@ submission:
 
 ui:
   enforce_quota: false
+  ai_backends:
+    enabled: true
+    api_connections: []
+    mcp_servers:
+      - name: test
+        url: "http://mcp_server:8081/sse"
+        transport: sse
+        timeout: 30
+    agent_profiles:
+      - name: analyst
+        description: "Test analyst agent"
+        system_message: "You are a test analyst assistant."
+        mcp_servers:
+          - test
+        max_iterations: 10
+        max_tokens: 1024
+      - name: triage
+        description: "Read-only triage agent"
+        system_message: "You read data only. No submissions."
+        mcp_servers:
+          - test
+        excluded_tools:
+          - submit_url
+        max_iterations: 5
+        max_tokens: 512

--- a/test/docker-compose.mcp-test.yml
+++ b/test/docker-compose.mcp-test.yml
@@ -1,0 +1,111 @@
+# docker-compose for MCP agent framework end-to-end tests.
+# Works on ARM (via platform: linux/amd64 emulation) and natively on amd64 CI runners.
+#
+# Usage:
+#   docker compose -f test/docker-compose.mcp-test.yml up --build --abort-on-container-exit
+#
+services:
+  # ── Infrastructure ──────────────────────────────────────
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.10.2
+    platform: linux/amd64
+    environment:
+      - xpack.security.enabled=true
+      - discovery.type=single-node
+      - logger.level=WARN
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - ELASTIC_PASSWORD=devpass
+    ports:
+      - "9200:9200"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -u elastic:devpass --silent --fail localhost:9200/_cluster/health || exit 1"]
+      interval: 10s
+      timeout: 10s
+      retries: 10
+
+  redis:
+    image: redis
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  minio:
+    image: minio/minio
+    environment:
+      MINIO_ROOT_USER: al_storage_key
+      MINIO_ROOT_PASSWORD: "Ch@ngeTh!sPa33w0rd"
+    ports:
+      - "9000:9000"
+    command: server /data
+
+  # ── Test MCP Server ─────────────────────────────────────
+  # Simulates an AL MCP server with dummy tools
+  mcp_server:
+    build:
+      context: ..
+      dockerfile: test/Dockerfile.mcp-test
+      platforms:
+        - linux/amd64
+    platform: linux/amd64
+    volumes:
+      - ../..:/opt/alv4/
+    command: python3 /opt/alv4/assemblyline-ui/test/test_mcp_server.py
+    ports:
+      - "8081:8081"
+    healthcheck:
+      test: ["CMD-SHELL", "curl --silent --fail http://localhost:8081/sse || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  # ── AL UI ───────────────────────────────────────────────
+  # Runs the Assemblyline UI with our MCP agent code
+  al_ui:
+    build:
+      context: ..
+      dockerfile: test/Dockerfile.mcp-test
+      platforms:
+        - linux/amd64
+    platform: linux/amd64
+    ports:
+      - "5000:5000"
+    volumes:
+      - ./config/:/etc/assemblyline/
+      - ../..:/opt/alv4/
+    working_dir: /opt/alv4/assemblyline-ui/assemblyline_ui/
+    command: python3 app.py
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      minio:
+        condition: service_started
+      mcp_server:
+        condition: service_healthy
+
+  # ── Test Runner ─────────────────────────────────────────
+  # Runs the end-to-end MCP agent tests against the live stack
+  test_runner:
+    build:
+      context: ..
+      dockerfile: test/Dockerfile.mcp-test
+      platforms:
+        - linux/amd64
+    platform: linux/amd64
+    volumes:
+      - ../..:/opt/alv4/
+    working_dir: /opt/alv4/assemblyline-ui/
+    environment:
+      - MCP_SERVER_URL=http://mcp_server:8081/sse
+      - AL_UI_URL=http://al_ui:5000
+    command: python3 /opt/alv4/assemblyline-ui/test/test_mcp_agent.py
+    depends_on:
+      al_ui:
+        condition: service_started
+      mcp_server:
+        condition: service_healthy

--- a/test/mcp_client.py
+++ b/test/mcp_client.py
@@ -1,0 +1,266 @@
+"""
+MCP (Model Context Protocol) client for AI agentic workflows.
+
+Connects to registered MCP servers, discovers their tools via the MCP protocol,
+and executes tool calls. MCP servers self-describe their capabilities, so no
+manual tool parameter configuration is needed — just register the server URL.
+
+Uses the official `mcp` Python SDK for protocol handling.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import threading
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from assemblyline.odm.models.config import MCPServerRegistration
+
+logger = logging.getLogger('assemblyline.ui.ai.mcp')
+
+
+class _MCPServerConnection:
+    """Manages a single MCP server connection in a dedicated thread.
+
+    The MCP SDK's sse_client uses anyio task groups that require the async
+    context manager to stay open for the lifetime of the connection. We run
+    each server in its own thread with its own event loop so the async with
+    block stays intact.
+    """
+
+    def __init__(self, name: str, url: str, transport: str, headers: dict, verify: bool = True):
+        self.name = name
+        self.url = url
+        self.transport = transport
+        self.headers = headers
+        self.verify = verify
+        self.tools: Dict[str, dict] = {}
+        self._session = None
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._thread: Optional[threading.Thread] = None
+        self._ready = threading.Event()
+        self._error: Optional[str] = None
+
+    def start(self, timeout: float = 30):
+        """Start the connection in a background thread. Blocks until ready or timeout."""
+        logger.info(f"MCP server '{self.name}': connecting to {self.url}")
+        self._thread = threading.Thread(target=self._run_loop, daemon=True)
+        self._thread.start()
+        if not self._ready.wait(timeout=timeout):
+            logger.error(f"MCP server '{self.name}': connection timed out after {timeout}s")
+            raise TimeoutError(f"MCP server '{self.name}' did not connect within {timeout}s")
+        if self._error:
+            logger.error(f"MCP server '{self.name}': connection failed: {self._error}")
+            raise ConnectionError(self._error)
+
+    def _run_loop(self):
+        """Thread entry: create event loop and run the MCP connection."""
+        self._loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self._loop)
+        try:
+            self._loop.run_until_complete(self._connect())
+        except Exception as e:
+            logger.error(f"MCP server '{self.name}': background thread error: {e}")
+            self._error = str(e)
+            self._ready.set()
+
+    async def _connect(self):
+        """Connect to the MCP server and keep the connection alive."""
+        from mcp import ClientSession
+        from mcp.client.sse import sse_client
+
+        # Build factory that respects the verify setting
+        def httpx_factory(**kwargs):
+            import httpx
+            kwargs.setdefault('verify', self.verify)
+            return httpx.AsyncClient(**kwargs)
+
+        async with sse_client(url=self.url, headers=self.headers,
+                              httpx_client_factory=httpx_factory) as streams:
+            if len(streams) == 3:
+                read_stream, write_stream, _ = streams
+            else:
+                read_stream, write_stream = streams
+
+            async with ClientSession(read_stream, write_stream) as session:
+                await session.initialize()
+                self._session = session
+
+                # Discover tools
+                tools_response = await session.list_tools()
+                for tool in tools_response.tools:
+                    self.tools[f"{self.name}.{tool.name}"] = {
+                        'server': self.name,
+                        'mcp_tool_name': tool.name,
+                        'description': tool.description or '',
+                        'input_schema': tool.inputSchema if hasattr(tool, 'inputSchema') else {},
+                    }
+
+                logger.info(f"MCP server '{self.name}': discovered {len(tools_response.tools)} tools")
+                self._ready.set()
+
+                # Keep connection alive until the thread is stopped
+                try:
+                    while True:
+                        await asyncio.sleep(1)
+                except asyncio.CancelledError:
+                    logger.debug(f"MCP server '{self.name}': connection thread cancelled")
+
+    async def call_tool(self, tool_name: str, arguments: dict) -> Any:
+        """Execute a tool call. Must be called from the server's own event loop."""
+        if not self._session:
+            raise RuntimeError(f"No session for MCP server '{self.name}'")
+        return await self._session.call_tool(tool_name, arguments=arguments)
+
+    def call_tool_sync(self, tool_name: str, arguments: dict, timeout: float = 120) -> Any:
+        """Execute a tool call from any thread, dispatching to the server's event loop."""
+        if not self._loop or not self._session:
+            logger.error(f"MCP server '{self.name}': no active connection for tool call '{tool_name}'")
+            raise RuntimeError(f"No active connection for MCP server '{self.name}'")
+        future = asyncio.run_coroutine_threadsafe(
+            self._session.call_tool(tool_name, arguments=arguments),
+            self._loop
+        )
+        try:
+            return future.result(timeout=timeout)
+        except TimeoutError:
+            logger.error(f"MCP server '{self.name}': tool call '{tool_name}' timed out after {timeout}s")
+            raise
+
+    def stop(self):
+        """Stop the connection."""
+        logger.info(f"MCP server '{self.name}': shutting down")
+        if self._loop:
+            for task in asyncio.all_tasks(self._loop):
+                self._loop.call_soon_threadsafe(task.cancel)
+            self._loop.call_soon_threadsafe(self._loop.stop)
+        if self._thread:
+            self._thread.join(timeout=5)
+
+
+class MCPToolRegistry:
+    """Discovers and executes tools from registered MCP servers.
+
+    Each MCP server runs in a dedicated background thread with its own event
+    loop, keeping the SSE connection alive. Tool calls are dispatched to the
+    correct server's event loop via thread-safe futures.
+    """
+
+    def __init__(self, mcp_servers: List['MCPServerRegistration']):
+        self._servers: Dict[str, Any] = {}  # config objects
+        self._connections: Dict[str, _MCPServerConnection] = {}
+        self._tools: Dict[str, dict] = {}
+
+        for server in mcp_servers:
+            self._servers[server.name] = server
+
+    def initialize(self):
+        """Connect to all MCP servers and discover their tools. Synchronous."""
+        logger.info(f"Initializing MCP connections for {len(self._servers)} server(s)")
+        for name, server in self._servers.items():
+            try:
+                headers = dict(server.headers) if server.headers else {}
+
+                # Inject FIC bearer token if configured
+                if server.use_fic:
+                    scope = server.fic_scope if hasattr(server, 'fic_scope') and server.fic_scope else 'https://cognitiveservices.azure.com/.default'
+                    headers = self._inject_fic_token(name, headers, scope)
+
+                verify = server.verify if hasattr(server, 'verify') else True
+                conn = _MCPServerConnection(name, server.url, server.transport, headers, verify=verify)
+                conn.start(timeout=server.timeout if hasattr(server, 'timeout') else 30)
+                self._connections[name] = conn
+                self._tools.update(conn.tools)
+            except Exception as e:
+                logger.error(f"Failed to connect to MCP server '{name}' at {server.url}: {e}")
+
+    @staticmethod
+    def _inject_fic_token(server_name: str, headers: dict, scope: str) -> dict:
+        """Acquire a token via Federated Identity Credentials and inject into headers."""
+        try:
+            from azure.identity import DefaultAzureCredential
+            credential = DefaultAzureCredential()
+            token = credential.get_token(scope).token
+            headers['Authorization'] = f'Bearer {token}'
+            logger.info(f"MCP server '{server_name}': acquired FIC token (scope={scope})")
+        except ImportError:
+            logger.warning(f"MCP server '{server_name}': azure-identity not installed, cannot use FIC")
+        except Exception as e:
+            logger.error(f"MCP server '{server_name}': FIC token acquisition failed: {e}")
+        return headers
+
+    def get_all_tool_names(self) -> List[str]:
+        return list(self._tools.keys())
+
+    def get_tools_for_servers(self, server_names: List[str]) -> List[str]:
+        return [name for name, info in self._tools.items() if info['server'] in server_names]
+
+    def filter_tools(self, server_names: List[str],
+                     include: List[str] = None, exclude: List[str] = None) -> List[str]:
+        available = self.get_tools_for_servers(server_names)
+        if include:
+            available = [t for t in available if t in include or t.split('.', 1)[-1] in include]
+        if exclude:
+            available = [t for t in available if t not in exclude and t.split('.', 1)[-1] not in exclude]
+        return available
+
+    def to_openai_tools(self, tool_names: List[str]) -> List[Dict]:
+        openai_tools = []
+        for name in tool_names:
+            tool_info = self._tools.get(name)
+            if not tool_info:
+                continue
+            schema = tool_info.get('input_schema', {})
+            openai_tools.append({
+                'type': 'function',
+                'function': {
+                    'name': name,
+                    'description': tool_info['description'],
+                    'parameters': schema if schema else {'type': 'object', 'properties': {}},
+                }
+            })
+        return openai_tools
+
+    def execute_tool(self, tool_name: str, arguments: Dict[str, Any]) -> str:
+        """Execute a tool call. Synchronous — dispatches to the server's event loop."""
+        tool_info = self._tools.get(tool_name)
+        if not tool_info:
+            logger.warning(f"Tool call for unknown tool: {tool_name}")
+            return json.dumps({'error': f'Unknown tool: {tool_name}'})
+
+        server_name = tool_info['server']
+        mcp_tool_name = tool_info['mcp_tool_name']
+
+        conn = self._connections.get(server_name)
+        if not conn:
+            logger.error(f"No active connection for MCP server '{server_name}' (tool: {tool_name})")
+            return json.dumps({'error': f'No active connection for MCP server: {server_name}'})
+
+        try:
+            result = conn.call_tool_sync(mcp_tool_name, arguments)
+
+            texts = []
+            for block in result.content:
+                if hasattr(block, 'text'):
+                    texts.append(block.text)
+                elif hasattr(block, 'data'):
+                    texts.append(f'[binary data: {len(block.data)} bytes]')
+
+            output = '\n'.join(texts) if texts else json.dumps({'result': 'empty'})
+            if len(output) > 64 * 1024:
+                logger.warning(f"Tool '{tool_name}' response truncated from {len(output)} to 64KB")
+                output = output[:64 * 1024] + '\n... [truncated]'
+            return output
+
+        except Exception as e:
+            logger.exception(f"MCP tool execution failed: {tool_name}")
+            return json.dumps({'error': f'Tool execution failed: {type(e).__name__}: {e}'})
+
+    def close(self):
+        """Close all MCP server connections."""
+        logger.info(f"Closing {len(self._connections)} MCP connection(s)")
+        for conn in self._connections.values():
+            conn.stop()
+        self._connections.clear()

--- a/test/run_mcp_tests.sh
+++ b/test/run_mcp_tests.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e
+
+echo "=== Starting test MCP server ==="
+python3 /opt/test_mcp_server.py &
+MCP_PID=$!
+
+# Wait for MCP server to be ready
+for i in $(seq 1 30); do
+    if curl -sf -o /dev/null --max-time 2 http://localhost:8081/sse 2>/dev/null; then
+        echo "MCP server is ready"
+        break
+    fi
+    # Also try a simple TCP check
+    if python3 -c "import socket; s=socket.socket(); s.settimeout(1); s.connect(('localhost',8081)); s.close()" 2>/dev/null; then
+        echo "MCP server is ready (port open)"
+        break
+    fi
+    echo "Waiting for MCP server... ($i/30)"
+    sleep 1
+done
+
+echo ""
+echo "=== Running MCP agent tests ==="
+export MCP_SERVER_URL=http://localhost:8081/sse
+python3 /opt/test_mcp_agent.py
+TEST_EXIT=$?
+
+# Cleanup
+kill $MCP_PID 2>/dev/null || true
+exit $TEST_EXIT

--- a/test/test_mcp_agent.py
+++ b/test/test_mcp_agent.py
@@ -1,0 +1,253 @@
+"""
+End-to-end tests for the MCP agent framework.
+
+Tests:
+  1. MCP tool discovery — connect to MCP server, verify tools are discovered
+  2. MCP tool execution — call tools and verify responses
+  3. OpenAI tool format — verify conversion to function-calling format
+  4. Agent profile filtering — verify tool scoping works
+  5. AL API: list agent profiles — GET /api/v4/assistant/agents/
+  6. AL API: agentic conversation — POST /api/v4/assistant/agents/<name>/
+
+Usage:
+    # Run via docker compose (recommended — works on ARM and amd64):
+    docker compose -f test/docker-compose.mcp-test.yml up --build --abort-on-container-exit
+
+    # Or standalone against a running MCP server (needs: pip install mcp):
+    MCP_SERVER_URL=http://localhost:8081/sse python test/test_mcp_agent.py
+"""
+import asyncio
+import importlib.util
+import json
+import os
+import sys
+import time
+
+MCP_SERVER_URL = os.environ.get("MCP_SERVER_URL", "http://localhost:8081/sse")
+AL_UI_URL = os.environ.get("AL_UI_URL", "")
+
+# Import mcp_client.py directly by file path to avoid pulling in the full
+# assemblyline dependency chain (which needs C extensions). The module uses
+# TYPE_CHECKING for its AL config imports so it loads standalone.
+_candidates = [
+    os.path.join(os.path.dirname(__file__), '..', 'assemblyline_ui', 'helper', 'ai', 'mcp_client.py'),
+    os.path.join(os.path.dirname(__file__), 'mcp_client.py'),
+    '/opt/mcp_client.py',
+]
+_mcp_path = next((p for p in _candidates if os.path.isfile(os.path.abspath(p))), None)
+if not _mcp_path:
+    print("ERROR: Cannot find mcp_client.py")
+    sys.exit(1)
+_spec = importlib.util.spec_from_file_location("mcp_client", os.path.abspath(_mcp_path))
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+MCPToolRegistry = _mod.MCPToolRegistry
+
+passed = 0
+failed = 0
+
+
+def report(name, ok, detail=""):
+    global passed, failed
+    if ok:
+        passed += 1
+    else:
+        failed += 1
+    print(f"  [{'PASS' if ok else 'FAIL'}] {name}" + (f" — {detail}" if detail else ""))
+
+
+# ── Test 1: MCP Tool Discovery ──────────────────────────
+
+def test_tool_discovery():
+    print("\n== Test 1: MCP Tool Discovery ==")
+
+    class FakeServer:
+        name = "test"
+        url = MCP_SERVER_URL
+        transport = "sse"
+        headers = {}
+        use_fic = False
+        verify = True
+        timeout = 30
+
+    registry = MCPToolRegistry([FakeServer()])
+    try:
+        registry.initialize()
+        tools = registry.get_all_tool_names()
+        report("Connected to MCP server", True)
+        report(f"Discovered {len(tools)} tools", len(tools) > 0, f"tools: {tools}")
+
+        expected = ["test.search_index", "test.get_file_info", "test.submit_url"]
+        for t in expected:
+            report(f"Found tool '{t}'", t in tools)
+
+        return registry
+    except Exception as e:
+        report("Connection failed", False, str(e))
+        return None
+
+
+# ── Test 2: MCP Tool Execution ──────────────────────────
+
+def test_tool_execution(registry):
+    print("\n== Test 2: MCP Tool Execution ==")
+    if not registry:
+        report("Skipped (no registry)", False)
+        return
+
+    result = registry.execute_tool("test.search_index", {"index": "file", "query": "*"})
+    parsed = json.loads(result)
+    report("search_index returned JSON", "total" in parsed, f"total={parsed.get('total')}")
+    report("search_index has items", len(parsed.get("items", [])) > 0)
+
+    result = registry.execute_tool("test.get_file_info", {"sha256": "a" * 64})
+    parsed = json.loads(result)
+    report("get_file_info returned data", parsed.get("file_type") is not None)
+
+    result = registry.execute_tool("test.submit_url", {"url": "http://example.com/test.exe"})
+    parsed = json.loads(result)
+    report("submit_url returned sid", parsed.get("sid") is not None)
+
+    result = registry.execute_tool("test.nonexistent", {})
+    parsed = json.loads(result)
+    report("Unknown tool returns error", "error" in parsed)
+
+
+# ── Test 3: OpenAI Tool Format ──────────────────────────
+
+def test_openai_format(registry):
+    print("\n== Test 3: OpenAI Tool Format ==")
+    if not registry:
+        report("Skipped (no registry)", False)
+        return
+
+    tools = registry.get_all_tool_names()
+    openai_tools = registry.to_openai_tools(tools)
+
+    report(f"Converted {len(openai_tools)} tools", len(openai_tools) == len(tools))
+
+    for tool in openai_tools:
+        name = tool["function"]["name"]
+        has_desc = bool(tool["function"].get("description"))
+        has_params = "parameters" in tool["function"]
+        has_required = "required" in tool["function"]["parameters"]
+        report(f"  {name}: valid schema", has_desc and has_params and has_required)
+
+
+# ── Test 4: Agent Profile Filtering ─────────────────────
+
+def test_profile_filtering(registry):
+    print("\n== Test 4: Agent Profile Filtering ==")
+    if not registry:
+        report("Skipped (no registry)", False)
+        return
+
+    all_tools = registry.filter_tools(server_names=["test"])
+    report("All tools from 'test'", len(all_tools) == 3, f"got {len(all_tools)}")
+
+    filtered = registry.filter_tools(server_names=["test"], exclude=["submit_url"])
+    report("Exclude submit_url", "test.submit_url" not in filtered and len(filtered) == 2)
+
+    filtered = registry.filter_tools(server_names=["test"], include=["search_index"])
+    report("Include only search_index", len(filtered) == 1)
+
+    filtered = registry.filter_tools(server_names=["nonexistent"])
+    report("Unknown server = empty", len(filtered) == 0)
+
+
+# ── Test 5: AL API — List Agent Profiles ────────────────
+
+def test_al_api_list_profiles():
+    print("\n== Test 5: AL API — List Agent Profiles ==")
+    if not AL_UI_URL:
+        report("Skipped (set AL_UI_URL)", True, "optional")
+        return
+
+    import requests
+
+    # Wait for AL UI to come up
+    print("  Waiting for AL UI...", end="", flush=True)
+    for attempt in range(60):
+        try:
+            resp = requests.get(f"{AL_UI_URL}/api/", timeout=3)
+            if resp.ok:
+                print(" ready")
+                break
+        except Exception:
+            pass
+        print(".", end="", flush=True)
+        time.sleep(3)
+    else:
+        print(" timeout")
+        report("AL UI reachable", False, "timed out after 3 minutes")
+        return
+
+    # GET /api/v4/assistant/agents/ (unauthenticated should 401)
+    resp = requests.get(f"{AL_UI_URL}/api/v4/assistant/agents/")
+    report("Unauthenticated returns 401", resp.status_code == 401)
+
+    # Create a session and login as admin
+    session = requests.Session()
+    login_resp = session.get(
+        f"{AL_UI_URL}/api/v4/auth/login/",
+        headers={"Authorization": "Basic YWRtaW46YWRtaW4="}  # admin:admin
+    )
+    if login_resp.status_code != 200:
+        report("Admin login", False, f"status={login_resp.status_code}")
+        return
+    report("Admin login", True)
+
+    # List agent profiles
+    resp = session.get(f"{AL_UI_URL}/api/v4/assistant/agents/")
+    if resp.status_code == 200:
+        data = resp.json()
+        profiles = data.get("api_response", [])
+        report("GET /agents/ returned profiles", len(profiles) > 0, f"count={len(profiles)}")
+        names = [p["name"] for p in profiles]
+        report("'analyst' profile exists", "analyst" in names)
+        report("'triage' profile exists", "triage" in names)
+    else:
+        report("GET /agents/", False, f"status={resp.status_code}")
+
+
+# ── Test 6: AL API — Agentic Conversation ───────────────
+
+def test_al_api_agentic():
+    print("\n== Test 6: AL API — Agentic Conversation ==")
+    if not AL_UI_URL:
+        report("Skipped (set AL_UI_URL)", True, "optional")
+        return
+
+    # This test requires a real LLM backend configured in api_connections.
+    # In CI, you'd set OPENAI_API_KEY and add it to the test config.
+    report("Skipped (needs LLM backend)", True,
+           "configure api_connections to test the full agentic loop")
+
+
+# ── Main ────────────────────────────────────────────────
+
+def main():
+    print("=" * 60)
+    print("MCP Agent Framework — End-to-End Tests")
+    print(f"  MCP Server: {MCP_SERVER_URL}")
+    print(f"  AL UI:      {AL_UI_URL or 'not configured'}")
+    print("=" * 60)
+
+    registry = test_tool_discovery()
+    test_tool_execution(registry)
+    test_openai_format(registry)
+    test_profile_filtering(registry)
+    test_al_api_list_profiles()
+    test_al_api_agentic()
+
+    if registry:
+        registry.close()
+
+    print(f"\n{'=' * 60}")
+    print(f"Results: {passed} passed, {failed} failed")
+    print("=" * 60)
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/test/test_mcp_server.py
+++ b/test/test_mcp_server.py
@@ -1,0 +1,154 @@
+"""
+Test MCP server for validating the AL agentic AI framework.
+
+Run this, then point the AL config at it to test tool discovery and execution.
+
+Usage:
+    pip install mcp
+    python test_mcp_server.py
+
+The server exposes three dummy tools that simulate what a real AL MCP server would provide.
+"""
+from mcp.server import Server
+from mcp.server.sse import SseServerTransport
+from mcp.types import Tool, TextContent
+from starlette.applications import Starlette
+from starlette.routing import Mount, Route
+import json
+import uvicorn
+
+app_server = Server("test-assemblyline-mcp")
+
+
+@app_server.list_tools()
+async def list_tools():
+    return [
+        Tool(
+            name="search_index",
+            description="Search an Assemblyline datastore index with a Lucene query",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "index": {
+                        "type": "string",
+                        "description": "Which index to search",
+                        "enum": ["alert", "file", "result", "signature", "submission"]
+                    },
+                    "query": {
+                        "type": "string",
+                        "description": "Lucene query string"
+                    },
+                    "rows": {
+                        "type": "integer",
+                        "description": "Max results (1-100)"
+                    }
+                },
+                "required": ["index", "query"]
+            }
+        ),
+        Tool(
+            name="get_file_info",
+            description="Get file metadata by SHA256",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "sha256": {
+                        "type": "string",
+                        "description": "SHA256 hash of the file"
+                    }
+                },
+                "required": ["sha256"]
+            }
+        ),
+        Tool(
+            name="submit_url",
+            description="Submit a URL for analysis",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "description": "URL to download and analyze"
+                    }
+                },
+                "required": ["url"]
+            }
+        ),
+    ]
+
+
+@app_server.call_tool()
+async def call_tool(name: str, arguments: dict):
+    if name == "search_index":
+        # Return fake search results
+        return [TextContent(
+            type="text",
+            text=json.dumps({
+                "total": 2,
+                "items": [
+                    {
+                        "sha256": "a" * 64,
+                        "file_type": "executable/windows/pe64",
+                        "size": 245760,
+                        "max_score": 750
+                    },
+                    {
+                        "sha256": "b" * 64,
+                        "file_type": "document/office/word",
+                        "size": 51200,
+                        "max_score": 100
+                    }
+                ]
+            }, indent=2)
+        )]
+
+    elif name == "get_file_info":
+        sha256 = arguments.get("sha256", "unknown")
+        return [TextContent(
+            type="text",
+            text=json.dumps({
+                "sha256": sha256,
+                "file_type": "executable/windows/pe64",
+                "size": 245760,
+                "magic": "PE32+ executable (GUI) x86-64, for MS Windows",
+                "entropy": 6.8,
+                "labels": ["malware", "trojan"],
+                "seen": {"count": 3, "first": "2026-05-01", "last": "2026-06-01"}
+            }, indent=2)
+        )]
+
+    elif name == "submit_url":
+        url = arguments.get("url", "unknown")
+        return [TextContent(
+            type="text",
+            text=json.dumps({
+                "sid": "test-submission-id-12345",
+                "sha256": "c" * 64,
+                "status": "submitted",
+                "message": f"URL '{url}' submitted for analysis"
+            }, indent=2)
+        )]
+
+    return [TextContent(type="text", text=json.dumps({"error": f"Unknown tool: {name}"}))]
+
+
+# Wire up SSE transport
+sse = SseServerTransport("/messages/")
+
+async def handle_sse(request):
+    async with sse.connect_sse(request.scope, request.receive, request._send) as streams:
+        await app_server.run(streams[0], streams[1], app_server.create_initialization_options())
+
+starlette_app = Starlette(
+    routes=[
+        Route("/sse", endpoint=handle_sse),
+        Mount("/messages/", app=sse.handle_post_message),
+    ]
+)
+
+if __name__ == "__main__":
+    print("Starting test MCP server on http://localhost:8081")
+    print("  SSE endpoint: http://localhost:8081/sse")
+    print("  Tools: search_index, get_file_info, submit_url")
+    print()
+    uvicorn.run(starlette_app, host="0.0.0.0", port=8081)


### PR DESCRIPTION
Add an agentic AI framework that discovers and executes tools from registered MCP servers. All tool capabilities come from MCP servers — no hardcoded tool definitions.

**New files:**
- \helper/ai/mcp_client.py\: MCPToolRegistry — connects to MCP servers, discovers tools via tools/list, converts to OpenAI function-calling format, executes via tools/call

**Modified files:**
- \helper/ai/base.py\: AIAgentPool loads MCP registry + agent profiles, exposes agentic_conversation()
- \helper/ai/openai.py\: async agentic_conversation() with MCP tool execution loop
- \api/v4/assistant.py\: New endpoints GET /agents/ and POST /agents/<name>/
- \api/v4/user.py\: Expose agent_profiles in user settings

**Depends on:** CybercentreCanada/assemblyline-base#2148
**Related:** assemblyline-rust config struct PR